### PR TITLE
Report parse errors in YUML

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -1979,6 +1979,7 @@ def relationships_from_yuml(yuml):
 
     """
     classes = collections.defaultdict(dict)
+    match_comment = re.compile(r'^\s*//').search
 
     match_line = re.compile(
         r'\[(?P<left_classname>[^\]]+)\]'
@@ -1996,8 +1997,12 @@ def relationships_from_yuml(yuml):
         yuml_lines = yuml.strip().splitlines()
 
     for line in yuml_lines:
+        if match_comment(line):
+            continue
+
         match = match_line(line)
         if not match:
+            LOG.error("parse error in relationships_from_yuml at %s" % line)
             continue
 
         left_class = match.group('left_classname')


### PR DESCRIPTION
Note:  The named relationship examples in the comments no longer work.  I'm not sure of the exact proper syntax.  I think it should be:

```
    // Explicitly-Named Relationships
    [Pool]default_sr *-default_for_pools 1[SR]
    [Pool]suspend_image_sr *-suspend_image_for_pools[SR]
    [Pool]crash_dump_sr *-crash_dump_for_pools[SR]
```

change to 

```
    // Explicitly-Named Relationships
    [Pool]*default_sr-default_for_pools1[SR]
    [Pool]*suspend_image_sr-suspend_image_for_pools*[SR]
    [Pool]*crash_dump_sr-crash_dump_for_pools*[SR]
```

But I'm not certain.  Can you verify?
