### PR TITLE
Add global catalog per component

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -124,6 +124,16 @@ class ZenPack(ZenPackBase):
     def remove(self, app, leaveObjects=False):
         from Products.Zuul.interfaces import ICatalogTool
         if not leaveObjects:
+
+            # Remove Global Component Catalogs
+            dc = app.Devices
+            for catalog in self.GLOBAL_CATALOGS:
+                catObj = getattr(dc, catalog, None)
+                if catObj:
+                    LOG.info('Removing Catalog %s' % catalog)
+                    dc._delObject(catalog)
+
+            # Remove Components
             if self.NEW_COMPONENT_TYPES:
                 LOG.info('Removing %s components' % self.id)
                 cat = ICatalogTool(app.zport.dmd)
@@ -224,20 +234,57 @@ class ComponentBase(ModelBase):
                     'while getting device for %s' % (
                         obj, exc, self))
 
-    def get_catalog(self, name):
+    def get_catalog_name(self, name, scope):
+        if scope == 'device':
+            return '{}Search'.format(name)
+        else:
+            name = self.__module__.replace('.', '_')
+            return '{}Search'.format(name)
+
+    def get_catalog(self, name, scope, create=True):
         """Return catalog by name."""
         spec = self._get_catalog_spec(name)
         if not spec:
             return
 
-        try:
-            return getattr(self.device(), '{}Search'.format(name))
-        except AttributeError:
-            return self._create_catalog(name)
+        if scope == 'device':
+            try:
+                return getattr(self.device(), self.get_catalog_name(name, scope))
+            except AttributeError:
+                if create:
+                    return self._create_catalog(name, 'device')
+        else:
+            try:
+                return getattr(self.dmd.Device, self.get_catalog_name(name, scope))
+            except AttributeError:
+                if create:
+                    return self._create_catalog(name, 'global')
+        return
 
-    def get_catalogs(self):
+    def get_catalog_scopes(self, name):
+        """Return catalog scopes by name."""
+        spec = self._get_catalog_spec(name)
+        if not spec:
+            []
+
+        scopes = [spec['indexes'][x].get('scope', 'device') for x in spec['indexes']]
+        if 'both' in scopes:
+            scopes = [x for x in scopes if x != 'both']
+            scopes.append('device')
+            scopes.append('global')
+        return set(scopes)
+
+    def get_catalogs(self, whiteList=None):
         """Return all catalogs for this class."""
-        return [self.get_catalog(name) for name in self._catalogs]
+        catalogs = []
+        for name in self._catalogs:
+            for scope in self.get_catalog_scopes(name):
+                if not whiteList:
+                    catalogs.append(self.get_catalog(name, scope))
+                else:
+                    if scope in whiteList:
+                        catalogs.append(self.get_catalog(name, scope, create=False))
+        return catalogs
 
     def _get_catalog_spec(self, name):
         if not hasattr(self, '_catalogs'):
@@ -259,7 +306,7 @@ class ComponentBase(ModelBase):
 
         return spec
 
-    def _create_catalog(self, name):
+    def _create_catalog(self, name, scope='device'):
         """Create and return catalog defined by name."""
         from Products.ZCatalog.Catalog import CatalogError
         from Products.ZCatalog.ZCatalog import manage_addZCatalog
@@ -270,13 +317,23 @@ class ComponentBase(ModelBase):
         if not spec:
             return
 
-        catalog_name = '{}Search'.format(name)
+        if scope == 'device':
+            catalog_name = self.get_catalog_name(name, scope)
 
-        device = self.device()
-        if not hasattr(device, catalog_name):
-            manage_addZCatalog(device, catalog_name, catalog_name)
+            device = self.device()
+            if not hasattr(device, catalog_name):
+                manage_addZCatalog(device, catalog_name, catalog_name)
 
-        zcatalog = device._getOb(catalog_name)
+            zcatalog = device._getOb(catalog_name)
+        else:
+            catalog_name = self.get_catalog_name(name, scope)
+            deviceClass = self.dmd.Devices
+
+            if not hasattr(deviceClass, catalog_name):
+                manage_addZCatalog(deviceClass, catalog_name, catalog_name)
+
+            zcatalog = deviceClass._getOb(catalog_name)
+
         catalog = zcatalog._catalog
 
         classname = spec.get(
@@ -304,7 +361,11 @@ class ComponentBase(ModelBase):
                 # Index already exists.
                 pass
             else:
-                results = ICatalogTool(device).search(types=(classname,))
+                if scope == 'device':
+                    results = ICatalogTool(device).search(types=(classname,))
+                else:
+                    results = ICatalogTool(deviceClass).search(types=(classname,))
+
                 for result in results:
                     result.getObject().index_object()
 
@@ -1091,6 +1152,16 @@ class ZenPackSpec(object):
 
         attributes['NEW_COMPONENT_TYPES'] = self.NEW_COMPONENT_TYPES
         attributes['NEW_RELATIONS'] = self.NEW_RELATIONS
+        attributes['GLOBAL_CATALOGS'] = []
+        global_catalog_classes = {}
+        for (class_, class_spec) in self.classes.items():
+            for (p, property_spec) in class_spec.properties.items():
+                if property_spec.index_scope in ('both', 'global'):
+                    global_catalog_classes[class_] = True
+                    continue
+        for class_ in global_catalog_classes:
+            catalog = ".".join([self.name, class_]).replace(".", "_")
+            attributes['GLOBAL_CATALOGS'].append('{}Search'.format(catalog))
 
         return create_class(get_symbol_name(self.name),
                             get_symbol_name(self.name, 'schema'),
@@ -1453,8 +1524,19 @@ class ClassSpec(object):
                             'id': {'type': 'field'},
                         }
                     }
-
                 catalogs[self.name]['indexes'].update(pindexes)
+                scopes = [catalogs[self.name]['indexes'][x]['scope'] for x in catalogs[self.name]['indexes'] if x != 'id']
+
+                if 'both' in scopes:
+                    scope_id = 'both'
+                elif 'global' in scopes and 'device' in scopes:
+                    scope_id = 'both'
+                elif 'global' in scopes and 'device' not in scopes:
+                    scope_id = 'global'
+                else:
+                    scope_id = 'device'
+
+                catalogs[self.name]['indexes']['id']['scope'] = scope_id
 
         # Add local relations.
         for name, spec in self.relationships.iteritems():
@@ -1897,7 +1979,8 @@ class ClassPropertySpec(object):
             enum=None,
             datapoint=None,
             datapoint_default=None,
-            datapoint_cached=True
+            datapoint_cached=True,
+            index_scope='device'
             ):
         """TODO."""
         self.class_spec = class_spec
@@ -1906,6 +1989,7 @@ class ClassPropertySpec(object):
         self.label = label or self.name
         self.short_label = short_label or self.label
         self.index_type = index_type
+        self.index_scope = index_scope
         self.label_width = label_width
         self.content_width = content_width or label_width
         self.display = display
@@ -1933,6 +2017,11 @@ class ClassPropertySpec(object):
                 "Property '%s': api_backendtype must be 'property' or 'method', not '%s'"
                 % (name, self.api_backendtype))
 
+        if self.index_scope not in ('device', 'global', 'both'):
+            raise TypeError(
+                "Property '%s': index_scope must be 'device', 'global', or 'both', not '%s'"
+                % (name, self.index_scope))
+
         # Force properties into the 4.0 - 4.9 order range.
         if not order:
             self.order = 4.5
@@ -1958,7 +2047,8 @@ class ClassPropertySpec(object):
             return {}
 
         return {
-            self.name: {'type': self.index_type},
+            self.name: {'type': self.index_type,
+                        'scope': self.index_scope},
             }
 
     @property


### PR DESCRIPTION
```
        'properties': {
            'serviceTag':  {'label': 'Service Tag',
                            'index_type': 'field',
                            'index_scope': 'global'},
             }
        }
```

scopes allowed:   global, device, both

global means this property will only be indexed to a catalog in dmd.Devices named
ZenPacks_zenoss_ExampleZenPack_ExampleComponentSearch

device will just create a catalog on a device named ExampleComponentSearch

Both will create both catalogs.

This feature also handles removing these extra catalogs upon zenpack removal.
