### PR TITLE
Fixes the following error at model time:

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -177,7 +177,7 @@ class DeviceBase(ModelBase):
     """
 
     def search(self, name, *args, **kwargs):
-        return catalog_search(self, name, args, kwargs)
+        return catalog_search(self, name, *args, **kwargs)
 
 
 class ComponentBase(ModelBase):


### PR DESCRIPTION
File "/opt/zenoss/Products/DataCollector/ApplyDataMap.py", line 217, in _applyDataMap
changed = self._updateRelationship(tobj, datamap)
File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.PythonCollector-1.4.0-py2.7.egg/ZenPacks/zenoss/PythonCollector/patches/platform.py", line 36, in _updateRelationship
return original(self, device, relmap)
File "/opt/zenoss/Products/DataCollector/ApplyDataMap.py", line 271, in _updateRelationship
objchange = self._updateObject(obj, objmap)
File "/opt/zenoss/Products/DataCollector/ApplyDataMap.py", line 389, in _updateObject
setter(*args)
File "/mnt/jwilmes/dev/git/ZenPacks.zenoss.OpenStack/ZenPacks/zenoss/OpenStack/zenpacklib.py", line 2651, in setter
self.setIdForRelationship(relationship, id_or_ids)
File "/mnt/jwilmes/dev/git/ZenPacks.zenoss.OpenStack/ZenPacks/zenoss/OpenStack/zenpacklib.py", line 404, in setIdForRelationship
for result in self.device().search('ComponentBase', id=id_):
File "/mnt/jwilmes/dev/git/ZenPacks.zenoss.OpenStack/ZenPacks/zenoss/OpenStack/zenpacklib.py", line 180, in search
return catalog_search(self, name, args, kwargs)
File "/mnt/jwilmes/dev/git/ZenPacks.zenoss.OpenStack/ZenPacks/zenoss/OpenStack/zenpacklib.py", line 2730, in catalog_search
.format(type(args[0]).**name**))
TypeError: search() argument must be a BaseQuery or a dict, not 'tuple'
: <no traceback>
