### PR TITLE
Restrict relationship infos for ToMany relations.

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -3133,11 +3133,11 @@ class ClassRelationshipSpec(Spec):
         """Return Info properties dict."""
         properties = {}
 
-        if not isinstance(self.schema, (ToOne)):
+        if isinstance(self.schema, (ToOne)):
+            properties[self.name] = RelationshipInfoProperty(self.name)
+        else:
             relname_count = '{}_count'.format(self.name)
             properties[relname_count] = RelationshipLengthProperty(self.name)
-
-        properties[self.name] = RelationshipInfoProperty(self.name)
 
         return properties
 


### PR DESCRIPTION
API users were running into serious performance issues because when they
called getInfo on zenpacklib components it would recursively build an
info tree for everything containing under that component.

The IInfo already restricts ToMany relationship information to just show
counts of containing relationships.

This change only impact API consumers. It has no affect on the web
interface.