### PR TITLE
Make !ZenPackSpec root tag implicit.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+default: help
+
+help:
+	@echo "Please use 'make <target>' where <target> is one of.."
+	@echo "  test    Runs all tests in tests/ directory."
+
+test:
+	python -m unittest discover -s tests

--- a/tests/data/zenpacks/ZenPacks.zenoss.ZPLTest1/ZenPacks/zenoss/ZPLTest1/zenpack.yaml
+++ b/tests/data/zenpacks/ZenPacks.zenoss.ZPLTest1/ZenPacks/zenoss/ZPLTest1/zenpack.yaml
@@ -1,6 +1,5 @@
-!ZenPackSpec
 name: ZenPacks.zenoss.ZPLTest1
-zProperties: !ZenPackSpec
+zProperties:
   DEFAULTS:
     category: ZPLTest1
   zZPLTest1HealthInterval:
@@ -39,7 +38,7 @@ class_relationships:
 - VzBrCP 1:M FvRsCons
 - VzBrCP 1:M VnsGraphInst
 - VnsLDevVip 1:M VnsNodeInst
-device_classes: !ZenPackSpec
+device_classes:
   /Network/ZPLTest1:
     templates:
       APIC:
@@ -246,7 +245,7 @@ device_classes: !ZenPackSpec
               Ingress:
                 dpName: eqptIngrTotal_utilAvg
                 format: '%7.2lf%%'
-classes: !ZenPackSpec
+classes:
   DEFAULTS:
     base: [ManagedObject]
   APIC:
@@ -462,4 +461,3 @@ classes: !ZenPackSpec
     meta_type: ZPLTest1Contract
     label: Contract
     order: !!float '14'
-

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -2,7 +2,7 @@
 
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2013-2014, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2013-2015, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -4499,6 +4499,8 @@ if YAML_INSTALLED:
     Dumper.add_representer(ClassRelationshipSpec, represent_spec)
     Dumper.add_representer(RelationshipSchemaSpec, represent_relschemaspec)
     Loader.add_constructor(u'!ZenPackSpec', construct_zenpackspec)
+
+    yaml.add_path_resolver(u'!ZenPackSpec', [], Loader=Loader)
 
     def load_yaml(yaml_filename=None):
         """Load YAML from yaml_filename.


### PR DESCRIPTION
This makes it possible to create a YAML file with no explicit tagging or
typing.