### PR TITLE
Fix error that occurs during zenpack installation when pyyaml is not ins...

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -1302,12 +1302,13 @@ class ZenPackSpec(Spec):
 
         # The parameters from which this zenpackspec was originally
         # instantiated.
-        self.specparams = ZenPackSpecParams(
-            name,
-            zProperties=zProperties,
-            classes=classes,
-            class_relationships=class_relationships,
-            device_classes=device_classes)
+        if YAML_INSTALLED:
+            self.specparams = ZenPackSpecParams(
+                name,
+                zProperties=zProperties,
+                classes=classes,
+                class_relationships=class_relationships,
+                device_classes=device_classes)
 
         self.name = name
         self.NEW_COMPONENT_TYPES = []

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -1309,6 +1309,8 @@ class ZenPackSpec(Spec):
                 classes=classes,
                 class_relationships=class_relationships,
                 device_classes=device_classes)
+        else:
+            self.specparams = None
 
         self.name = name
         self.NEW_COMPONENT_TYPES = []


### PR DESCRIPTION
...talled.  install() is still relied upon to actually tell the user that pyyaml is missing, but now it will get to that point.

Fixes ZEN-17264