### PR TITLE
Fix inheritance of monkeypatched relationships.

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -21,6 +21,7 @@ import Globals
 from Products.ZenModel.Device import Device
 from Products.ZenModel.DeviceComponent import DeviceComponent
 from Products.ZenModel.ManagedEntity import ManagedEntity
+from Products.ZenRelations.ToManyRelationship import ToManyRelationship
 from Products.ZenRelations.ToManyContRelationship import ToManyContRelationship
 from Products.ZenRelations.ToOneRelationship import ToOneRelationship
 from Products.ZenRelations.zPropertyCategory import getzPropertyCategory
@@ -211,6 +212,8 @@ class TestSchema(zenpacklib.TestCase):
         self.assert_properties(apic1, ('manageIp', 'priority'))
 
         self.assert_relationships(apic1, (
+            ('dependencies', ToManyRelationship),  # from ManagedEntity
+            ('deviceClass', ToOneRelationship),  # from Device
             ('fabricPods', ToManyContRelationship),
             ('fvTenants', ToManyContRelationship),
             ))
@@ -370,6 +373,7 @@ class TestSchema(zenpacklib.TestCase):
         self.assert_properties(pod1, ('snmpindex', 'monitor'))
 
         self.assert_relationships(pod1, (
+            ('dependencies', ToManyRelationship),  # from ManagedEntity
             ('apic', ToOneRelationship),
             ('fabricNodes', ToManyContRelationship),
             ))


### PR DESCRIPTION
There was an issue with all ZenPacks using zenpacklib to device a new
Device class. When another ZenPack that monkeypatched Device._relations
was loaded after a zenpacklib ZenPack in easy-install.pth, the
zenpacklib ZenPack Device subclass wouldn't get the monkeypatched
relationships. This was because it would copy and extend
Device._relations before it had been monkeypatched.

This fix resolves that problem for relationships and properties by
inheriting _relations and _properties from all base classes at runtime
instead of at class creation time.

Refs ZEN-17193.