### PR TITLE
Base component status on /Status w/o meta_type.

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -658,6 +658,18 @@ class ComponentBase(ModelBase):
                 # expects device() to return None, not to throw an exception.
                 return None
 
+    def getStatus(self, statClass='/Status'):
+        """Return the status number for this component.
+
+        Overridden to default statClass to /Status instead of
+        /Status/<self.meta_type>. Current practices do not include using
+        a separate event class for each component meta_type. The event
+        class plus component field already convey this level of
+        information.
+
+        """
+        return BaseDeviceComponent.getStatus(self, statClass=statClass)
+
     def getIdForRelationship(self, relationship):
         """Return id in ToOne relationship or None."""
         obj = relationship()


### PR DESCRIPTION
Zenoss platform behavior is currently (as of 5.0.2) to derive every
component's status property from the events under the
/Status/<component-meta_type> event class. Using a child event class
under /Status has long been deprecated as a best practice as the event's
component field already conveys the component context.

This change allows events in and under the /Status event class and
associated to the component to affect the component's status property.

Refs ZEN-17536.