### PR TITLE
Fix inherited rels and props not showing in UI.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,9 @@ Release 1.0.3
 Defects fixed
 -------------
 
-* import snmp datasource oid parameters as a string to workaround a ui test defect
+* Fix testing of SNMP datasources by converting OIDs to string.
+* Fix for inherited relationships and properties not appearing in UI.
+
 
 Release 1.0.2
 =============
@@ -17,6 +19,7 @@ Defects fixed
 * Fix handling of nested device class remove field.
 * Fix KeyError when removing non-existent device class.
 * Fix handling of datapoint rrdtype. (ZEN-18188)
+
 
 Release 1.0.1
 =============

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -2221,7 +2221,7 @@ class ClassSpec(Spec):
         for base in self.bases:
             if not isinstance(base, type):
                 class_spec = self.zenpack.classes[base]
-                properties.update(class_spec.properties)
+                properties.update(class_spec.inherited_properties())
 
         properties.update(self.properties)
 
@@ -2232,7 +2232,7 @@ class ClassSpec(Spec):
         for base in self.bases:
             if not isinstance(base, type):
                 class_spec = self.zenpack.classes[base]
-                relationships.update(class_spec.relationships)
+                relationships.update(class_spec.inherited_relationships())
 
         relationships.update(self.relationships)
 


### PR DESCRIPTION
Directly inherited relationships and properties were already working,
but not from any higher in the inheritance tree.