### PR TITLE
TestCase fixes.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,15 @@
 Release 1.0.4
 =============
 
+Features added
+--------------
+
+* TestCase: Automatically load ZenPack's configure.zcml if it exists.
+
 Defects fixed
 -------------
 
-* TODO
+* TestCase: Fix transaction error without DynamicView or Impact installed.
 
 
 Release 1.0.3

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -5198,14 +5198,19 @@ def enableTesting():
                 import ZenPacks.zenoss.DynamicView
                 zcml.load_config('configure.zcml', ZenPacks.zenoss.DynamicView)
             except ImportError:
-                return
+                pass
 
             try:
                 import ZenPacks.zenoss.Impact
                 zcml.load_config('meta.zcml', ZenPacks.zenoss.Impact)
                 zcml.load_config('configure.zcml', ZenPacks.zenoss.Impact)
             except ImportError:
-                return
+                pass
+
+            try:
+                zcml.load_config('configure.zcml', zenpack_module)
+            except IOError:
+                pass
 
             # BaseTestCast.afterSetUp already hides transaction.commit. So we also
             # need to hide transaction.abort.


### PR DESCRIPTION
* Automatically load ZenPack's configure.zcml if it exists.
* Fix transaction error without DynamicView or Impact installed.