### PR TITLE
Allow setting of details group on class properties

### DIFF
--- a/docs/yaml-classes-and-relationships.rst
+++ b/docs/yaml-classes-and-relationships.rst
@@ -413,6 +413,12 @@ order
   :Required: No
   :Type: integer
   :Default Value: 45
+
+group
+  :Description: Name of group in details.
+  :Required: No
+  :Type: string
+  :Default Value: None
   
 editable
   :Description: Should this property be editable in details?

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -2925,6 +2925,7 @@ class ClassPropertySpec(Spec):
             grid_display=True,
             renderer=None,
             order=None,
+            group=None,
             editable=False,
             api_only=False,
             api_backendtype='property',
@@ -2973,6 +2974,9 @@ class ClassPropertySpec(Spec):
             :type renderer: str
             :param order: TODO
             :type order: float
+            :param group: Optional name of details group.
+            :param default: Default Value
+            :type group: str
             :param editable: TODO
             :type editable: bool
             :param api_only: TODO
@@ -3013,6 +3017,7 @@ class ClassPropertySpec(Spec):
             self.renderer = 'Zenoss.render.zenpacklib_{zenpack_id_prefix}_entityLinkFromGrid'.format(
                 zenpack_id_prefix=self.class_spec.zenpack.id_prefix)
 
+        self.group = group
         self.editable = bool(editable)
         self.api_only = bool(api_only)
         self.api_backendtype = api_backendtype
@@ -3092,6 +3097,7 @@ class ClassPropertySpec(Spec):
         return {
             self.name: schema_map[self.type_](
                 title=_t(self.label),
+                group=self.group,
                 alwaysEditable=self.editable,
                 order=self.order)
             }


### PR DESCRIPTION
Following simple patch allows setting "group" name for class properties. Properties can be then added to the "Overview" group, their own groups or left in default.
![group](https://cloud.githubusercontent.com/assets/414850/9819827/8dc43d4e-58b0-11e5-8fc5-2b953a4ad59f.png)
