### PR TITLE
Fix __init__.py references

### DIFF
--- a/docs/tutorial-http-api/add-device-class.rst
+++ b/docs/tutorial-http-api/add-device-class.rst
@@ -114,6 +114,8 @@ Create a ``wunderground.zenbatchload`` file with the following contents.
 
     /Devices/WeatherUnderground
     wunderground.com zWundergroundAPIKey='<your-api-key>', zWundergroundLocations=['Austin, TX', 'Des Moines, IA']
+    
+Before you remodel the device, you need to remove the existing device, or its stored state will prevent remodeling.  Find your wunderground.com device in the device list.  Select it, and click the Remove Devices button (has a Do Not Enter icon).
 
 Now run the following command to load from that file.
 

--- a/docs/tutorial-http-api/add-device-class.rst
+++ b/docs/tutorial-http-api/add-device-class.rst
@@ -3,7 +3,7 @@ Add a Device Class
 ******************
 
 To support adding our special `WundergroundDevice` devices that we defined in
-``__init__.py`` to Zenoss we must create a new device class. This will give us
+``zenpack.yaml`` to Zenoss we must create a new device class. This will give us
 control of the `zPythonClass` configuration property that defines what type of
 devices will be created. It will also allow us to control what modeler plugins
 and monitoring templates will be used.

--- a/docs/tutorial-http-api/datasource-plugin-datapoints.rst
+++ b/docs/tutorial-http-api/datasource-plugin-datapoints.rst
@@ -127,113 +127,114 @@ Follow these steps to update the monitoring template:
       device_classes:
         /WeatherUnderground:
           templates:
-            description: Location weather monitoring using the Weather Underground API.
-            targetPythonClass: ZenPacks.training.WeatherUnderground.WundergroundLocation
-
-            datasources:
-              conditions:
-                type: Python
-                plugin_classname: ZenPacks.training.WeatherUnderground.dsplugins.Conditions
-                cycletime: "600"
-          
-                datapoints:
-                  temp_c: GAUGE
-                  feelslike_c: GAUGE
-                  heat_index_c: GAUGE
-                  windchill_c: GAUGE
-                  dewpoint_c: GAUGE
-                  relative_humidity: GAUGE
-                  pressure_mb: GAUGE
-                  precip_1hr_metric: GAUGE
-                  UV: GAUGE
-                  wind_kph: GAUGE
-                  wind_gust_kph: GAUGE
-                  visibility_km: GAUGE
-      
-            graphs:
-              Temperatures:
-                units: degrees C.
-          
-                graphpoints:
-                  Temperature:
-                    dpName: conditions_temp_c
-                    format: "%7.2lf"
-          
-                  Feels Like:
-                    dpName: conditions_feelslike_c
-                    format: "%7.2lf"
-          
-                  Heat Index:
-                    dpName: conditions_heat_index_c
-                    format: "%7.2lf"
-          
-                  Wind Chill:
-                    dpName: conditions_windchilltemp_c
-                    format: "%7.2lf"
-          
-                  Dewpoint:
-                    dpName: conditions_dewpoint_c
-                    format: "%7.2lf"
-          
-              Relative Humidity:
-                units: percent
-                miny: 0
-                maxy: 100
-          
-                graphpoints:
-                  Relative Humidity:
-                    dpName: conditions_relative_humidity
-                    format: "%7.2lf%%"
-          
-              Pressure:
-                units: millibars
-                miny: 0
-          
-                graphpoints:
-                  Pressure:
-                    dpName: conditions_pressure_mb
-                    format: "%7.0lf"
-          
-              Precipitation:
-                units: centimeters
-                miny: 0
-          
-                graphpoints:
-                  1 Hour:
-                    dpName: conditions_precip_1hr_metric
-                    format: "%7.2lf"
-          
-              UV Index:
-                units: UV index
-                miny: 0
-                maxy: 12
-          
-                graphpoints:
-                  UV Index:
-                    dpName: conditions_UV
-                    format: "%7.0lf"
-          
-              Wind Speed:
-                units: kph
-                miny: 0
-          
-                graphpoints:
-                  Sustained:
-                    dpName: conditions_wind_kph
-                    format: "%7.2lf"
-          
-                  Gust:
-                    dpName: conditions_wind_gust_kph
-                    format: "%7.2lf"
-          
-              Visibility:
-                units: kilometers
-                miny: 0
-          
-                graphpoints:
-                  Visibility:
-                    dpName: conditions_visibility_km
-                    format: "%7.2lf"
+            Location:
+              description: Location weather monitoring using the Weather Underground API.
+              targetPythonClass: ZenPacks.training.WeatherUnderground.WundergroundLocation
+  
+              datasources:
+                conditions:
+                  type: Python
+                  plugin_classname: ZenPacks.training.WeatherUnderground.dsplugins.Conditions
+                  cycletime: "600"
+            
+                  datapoints:
+                    temp_c: GAUGE
+                    feelslike_c: GAUGE
+                    heat_index_c: GAUGE
+                    windchill_c: GAUGE
+                    dewpoint_c: GAUGE
+                    relative_humidity: GAUGE
+                    pressure_mb: GAUGE
+                    precip_1hr_metric: GAUGE
+                    UV: GAUGE
+                    wind_kph: GAUGE
+                    wind_gust_kph: GAUGE
+                    visibility_km: GAUGE
+        
+              graphs:
+                Temperatures:
+                  units: degrees C.
+            
+                  graphpoints:
+                    Temperature:
+                      dpName: conditions_temp_c
+                      format: "%7.2lf"
+            
+                    Feels Like:
+                      dpName: conditions_feelslike_c
+                      format: "%7.2lf"
+            
+                    Heat Index:
+                      dpName: conditions_heat_index_c
+                      format: "%7.2lf"
+            
+                    Wind Chill:
+                      dpName: conditions_windchilltemp_c
+                      format: "%7.2lf"
+            
+                    Dewpoint:
+                      dpName: conditions_dewpoint_c
+                      format: "%7.2lf"
+            
+                Relative Humidity:
+                  units: percent
+                  miny: 0
+                  maxy: 100
+            
+                  graphpoints:
+                    Relative Humidity:
+                      dpName: conditions_relative_humidity
+                      format: "%7.2lf%%"
+            
+                Pressure:
+                  units: millibars
+                  miny: 0
+            
+                  graphpoints:
+                    Pressure:
+                      dpName: conditions_pressure_mb
+                      format: "%7.0lf"
+            
+                Precipitation:
+                  units: centimeters
+                  miny: 0
+            
+                  graphpoints:
+                    1 Hour:
+                      dpName: conditions_precip_1hr_metric
+                      format: "%7.2lf"
+            
+                UV Index:
+                  units: UV index
+                  miny: 0
+                  maxy: 12
+            
+                  graphpoints:
+                    UV Index:
+                      dpName: conditions_UV
+                      format: "%7.0lf"
+            
+                Wind Speed:
+                  units: kph
+                  miny: 0
+            
+                  graphpoints:
+                    Sustained:
+                      dpName: conditions_wind_kph
+                      format: "%7.2lf"
+            
+                    Gust:
+                      dpName: conditions_wind_gust_kph
+                      format: "%7.2lf"
+            
+                Visibility:
+                  units: kilometers
+                  miny: 0
+            
+                  graphpoints:
+                    Visibility:
+                      dpName: conditions_visibility_km
+                      format: "%7.2lf"
 
    You can refer to :ref:`monitoring-templates` for more information on creating
    monitoring templates in YAML.

--- a/docs/tutorial-http-api/datasource-plugin-datapoints.rst
+++ b/docs/tutorial-http-api/datasource-plugin-datapoints.rst
@@ -153,7 +153,7 @@ Follow these steps to update the monitoring template:
         
               graphs:
                 Temperatures:
-                  units: degrees C.
+                  units: "degrees C."
             
                   graphpoints:
                     Temperature:

--- a/docs/tutorial-http-api/datasource-plugin-datapoints.rst
+++ b/docs/tutorial-http-api/datasource-plugin-datapoints.rst
@@ -247,13 +247,13 @@ Follow these steps to update the monitoring template:
        
    .. note::
 
-   When you install the ZenPack after this change, you may get an error containing 
-   along the lines of `AttributeError: 'ZenPack' object has no attribute '__of__'`.
-   The resolution for this is to revert or comment out your changes to zenpack.yaml
-   and dsplugins.py, then run `zenpack --uninstall=ZenPacks.training.WeatherUnderground`.
-   
-   Once you do this, you should be able to reinstate your changes, and run the install
-   command above.
+      When you install the ZenPack after this change, you may get an error containing 
+      along the lines of `AttributeError: 'ZenPack' object has no attribute '__of__'`.
+      The resolution for this is to revert or comment out your changes to zenpack.yaml
+      and dsplugins.py, then run `zenpack --uninstall=ZenPacks.training.WeatherUnderground`.
+      
+      Once you do this, you should be able to reinstate your changes, and run the install
+      command above.
 
 3. Navigate to `Advanced` -> `Monitoring Templates` in the web interface to
    verify that the `Location` monitoring template has been updated with the

--- a/docs/tutorial-http-api/datasource-plugin-datapoints.rst
+++ b/docs/tutorial-http-api/datasource-plugin-datapoints.rst
@@ -244,6 +244,16 @@ Follow these steps to update the monitoring template:
    .. code-block:: bash
    
        zenpack --link --install $ZP_TOP_DIR
+       
+   .. note::
+
+   When you install the ZenPack after this change, you may get an error containing 
+   along the lines of `AttributeError: 'ZenPack' object has no attribute '__of__'`.
+   The resolution for this is to revert or comment out your changes to zenpack.yaml
+   and dsplugins.py, then run `zenpack --uninstall=ZenPacks.training.WeatherUnderground`.
+   
+   Once you do this, you should be able to reinstate your changes, and run the install
+   command above.
 
 3. Navigate to `Advanced` -> `Monitoring Templates` in the web interface to
    verify that the `Location` monitoring template has been updated with the

--- a/docs/tutorial-http-api/datasource-plugin-events.rst
+++ b/docs/tutorial-http-api/datasource-plugin-events.rst
@@ -60,7 +60,7 @@ Follow these instructions to define the dependency.
 
 4. Click `Save`.
 
-5. Export the ZenPack. (:ref:`export-zenpack`)
+5. Export the ZenPack. (:ref:`export-zenpack`).  The resulting objects.xml should have an empty XML object for this ZenPack.
 
 
 Create the Alerts Plugin

--- a/docs/tutorial-http-api/modeler-plugin.rst
+++ b/docs/tutorial-http-api/modeler-plugin.rst
@@ -42,6 +42,7 @@ Use the following steps to create our modeler plugin.
       
       # stdlib Imports
       import json
+      import urllib
       
       # Twisted Imports
       from twisted.internet.defer import inlineCallbacks, returnValue
@@ -94,7 +95,7 @@ Use the following steps to create our modeler plugin.
                   try:
                       response = yield getPage(
                           'http://autocomplete.wunderground.com/aq?query={query}'
-                          .format(query=location))
+                          .format(query=urllib.quote(location)))
       
                       response = json.loads(response)
                   except Exception, e:

--- a/docs/tutorial-http-api/modeler-plugin.rst
+++ b/docs/tutorial-http-api/modeler-plugin.rst
@@ -161,8 +161,8 @@ Use the following steps to create our modeler plugin.
       this relationship.
 
       Where does relname come from? It comes from the
-      ``[WundergroundDevice]++-[WundergroundLocation]`` relationship we defined
-      in ``__init__.py``. Because it's a *to-many* relationship to the
+      ``WundergroundDevice 1:MC WundergroundLocation`` relationship we defined
+      in ``zenpack.yaml``. Because it's a *to-many* relationship to the
       `WundergroundLocation` type, `zenpacklib` will name the relationship by
       lowercasing the first letter and adding an "s" to the end to make it
       plural.
@@ -237,7 +237,7 @@ Use the following steps to create our modeler plugin.
         good candidate for this. It will look something like "Austin, Texas".
 
       - `api_link` is a property we defined for the `WundergroundLocation`
-        class in ``__init__.py``. This is where we'll store the returned
+        class in ``zenpack.yaml``. This is where we'll store the returned
         *link* or `l` property. This will be important for monitoring the
         alerts and conditions of the location later on.
 

--- a/docs/tutorial-http-api/wunderground-api.rst
+++ b/docs/tutorial-http-api/wunderground-api.rst
@@ -38,9 +38,8 @@ Here's an example query for Austin, TX:
   :samp:`http://autocomplete.wunderground.com/aq?query=Austin%2C%20TX`
 
 .. note::
-   "Austin%2C%20TX" is the URL encoded version of "Austin, TX". We won't have
-   to worry about that when we work with it because our HTTP library
-   automatically encodes URLs.
+   "Austin%2C%20TX" is the URL encoded version of "Austin, TX". We will url encode
+   this data when we work with it.
 
 Here's the response to that example query for Austin, TX:
 


### PR DESCRIPTION
The two places I modified reference things defined in __init__.py, but all the __init__.py files seem to be largely empty.  I am guessing this is stuff that was defined in __init__.py in the original (non-ZPL) tutorial, but is now defined in zenpack.yaml.  I modified it to read how I think it should, but if it's wrong, feel free to reject the PR.