### PR TITLE
Feature/fix docs

### DIFF
--- a/docs/tutorial-snmp-device/component-modeling.rst
+++ b/docs/tutorial-snmp-device/component-modeling.rst
@@ -244,9 +244,9 @@ modeler plugin we previously created to model the sensors instead.
 
       The target `relname` we should use depends on a couple of things.  First, 
       all leading uppercase letters of the class name will be converted to lowercase,
-      i.e. `NetBotzTemperatureSensor` becomes `netBotzTemperatureSensor`.  Second, the 
+      i.e. ``NetBotzTemperatureSensor`` becomes ``netBotzTemperatureSensor``.  Second, the 
       letter 's' is added to the end if it is a ToMany* relationship, i.e. 
-      `netBotzTemperatureSensor` becomes `netBotzTemperatureSensors`
+      ``netBotzTemperatureSensor`` becomes ``netBotzTemperatureSensors``
 
       Setting `relname` to ``netBotzTemperatureSensors`` will cause the
       `self.relMap` call to create a `RelationshipMap` that will be applied to

--- a/docs/tutorial-snmp-device/component-modeling.rst
+++ b/docs/tutorial-snmp-device/component-modeling.rst
@@ -246,7 +246,7 @@ modeler plugin we previously created to model the sensors instead.
       all leading uppercase letters of the class name will be converted to lowercase,
       i.e. ``NetBotzTemperatureSensor`` becomes ``netBotzTemperatureSensor``.  Second, the 
       letter 's' is added to the end if it is a ToMany* relationship, i.e. 
-      ``netBotzTemperatureSensor`` becomes ``netBotzTemperatureSensors``
+      ``netBotzTemperatureSensor`` becomes ``netBotzTemperatureSensors``.
 
       Setting `relname` to ``netBotzTemperatureSensors`` will cause the
       `self.relMap` call to create a `RelationshipMap` that will be applied to

--- a/docs/tutorial-snmp-device/component-modeling.rst
+++ b/docs/tutorial-snmp-device/component-modeling.rst
@@ -242,11 +242,11 @@ modeler plugin we previously created to model the sensors instead.
       when the `self.relMap` and `self.objectMap` methods are called in the
       `process` method.
 
-      The target `relname` we should use depends on a couple of things.
-         a) All leading uppercase letters of the class name will be converted to lowercase,
-            i.e. `NetBotzTemperatureSensor` becomes `netBotzTemperatureSensor`
-         b) An 's' is added to the end if it is a ToMany* relationship, 
-            i.e. `netBotzTemperatureSensor` becomes `netBotzTemperatureSensors`
+      The target `relname` we should use depends on a couple of things.  First, 
+      all leading uppercase letters of the class name will be converted to lowercase,
+      i.e. `NetBotzTemperatureSensor` becomes `netBotzTemperatureSensor`.  Second, the 
+      letter 's' is added to the end if it is a ToMany* relationship, i.e. 
+      `netBotzTemperatureSensor` becomes `netBotzTemperatureSensors`
 
       Setting `relname` to ``netBotzTemperatureSensors`` will cause the
       `self.relMap` call to create a `RelationshipMap` that will be applied to

--- a/docs/tutorial-snmp-device/component-modeling.rst
+++ b/docs/tutorial-snmp-device/component-modeling.rst
@@ -242,6 +242,12 @@ modeler plugin we previously created to model the sensors instead.
       when the `self.relMap` and `self.objectMap` methods are called in the
       `process` method.
 
+      The target `relname` we should use depends on a couple of things.
+         a) All leading uppercase letters of the class name will be converted to lowercase,
+            i.e. `NetBotzTemperatureSensor` becomes `netBotzTemperatureSensor`
+         b) An 's' is added to the end if it is a ToMany* relationship, 
+            i.e. `netBotzTemperatureSensor` becomes `netBotzTemperatureSensors`
+
       Setting `relname` to ``netBotzTemperatureSensors`` will cause the
       `self.relMap` call to create a `RelationshipMap` that will be applied to
       the `netBotzTemperatureSensors` relationship defined on the


### PR DESCRIPTION
Added note to component modeling section of SNMP tutorial describing how a relname is determined.

Addresses:  https://zenoss.zendesk.com/agent/tickets/108454