### PR TITLE
Fix dynamicview_relations type issue.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+Release 1.0.7
+=============
+
+Defects fixed
+-------------
+
+* Fix dynamicview_relations type issue.
+
 Release 1.0.6
 =============
 

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -5859,12 +5859,23 @@ if DYNAMICVIEW_INSTALLED:
 
         def relations(self, type=TAG_ALL):
             target = IRelatable(self._adapted)
+            relations = getattr(self._adapted, 'dynamicview_relations', {})
 
-            for tag in (TAG_ALL, type):
-                relations = getattr(self._adapted, 'dynamicview_relations', {})
-                for methodname in relations.get(tag, []):
-                    for remote in self.get_remote_relatables(methodname):
-                        yield BaseRelation(target, remote, type)
+            # Group methods by type to allow easy tagging of multiple types
+            # per yielded relation. This allows supporting the special TAG_ALL
+            # type without duplicating work or relations.
+            types_by_methodname = collections.defaultdict(set)
+            if type == TAG_ALL:
+                for ltype, lmethodnames in relations.items():
+                    for lmethodname in lmethodnames:
+                        types_by_methodname[lmethodname].add(ltype)
+            else:
+                for lmethodname in relations.get(type, []):
+                    types_by_methodname[lmethodname].add(type)
+
+            for methodname, type_set in types_by_methodname.items():
+                for remote in self.get_remote_relatables(methodname):
+                    yield BaseRelation(target, remote, list(type_set))
 
         def get_remote_relatables(self, methodname):
             """Generate object relatables returned by adapted.methodname()."""


### PR DESCRIPTION
When zenpacklib created BaseRelation objects for DynamicView for defined
dynamicview_relations, it would pass in the type/tag as a string instead
of a iterable of strings. This would end up tagging the relationship
with one tag per character in the string instead of the correct name.