### PR TITLE
Fix filtering of monitoring templates out of exported XML.

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -3621,6 +3621,10 @@ class RRDTemplateSpec(Spec):
         # exported to objects.xml  (contained objects will also be excluded)
         template.zpl_managed = True
 
+        # Add this RRDTemplate to the zenpack.
+        zenpack_name = self.deviceclass_spec.zenpack_spec.name
+        template.addToZenPack(pack=zenpack_name)
+
         if not existing_template:
             self.speclog.info("adding template")
 

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -344,7 +344,7 @@ class ZenPack(ZenPackBase):
 
             def objectValues(self):
                 # proxy the remote objects on ToManyContRelationships
-                return [FilteredZenPackable.wrap(x.__of__(self)) for x in self._objects.values()]
+                return [FilteredZenPackable.wrap(x.__of__(self)) for x in self.aq_acquire('_objects').values()]
 
             def exportXmlRelationships(self, ofile, ignorerels=[]):
                 for rel in self.getRelationships():
@@ -360,8 +360,7 @@ class ZenPack(ZenPackBase):
                     LOG.info("Excluding %s from export (ZPL-managed object)" % path)
                     return
                 else:
-                    LOG.info("Including %s from export (not a ZPL-managed object)" % path)
-                    return self.aq_parent.exportXml(*args, **kwargs)
+                    return self.aq_parent.exportXml.__func__(self, *args, **kwargs)
 
         class FilteredZenPack(ZenPackBase, Acquisition.Implicit):
 
@@ -375,7 +374,7 @@ class ZenPack(ZenPackBase):
                 return filtered
 
             def packables(self):
-                packables = self.aq_parent.packables()
+                packables = [p for p in self.aq_parent.packables() if not getattr(p, 'zpl_managed', False)]
                 return [FilteredZenPackable.wrap(x) for x in packables]
 
         return ZenPackBase.manage_exportPack(


### PR DESCRIPTION
I'm a little baffled at this.  I know that when I wrote it, I had to do the explicit acquisition wrapper stuff to make sure that the wrapped objects were both zope proxies and kept their acquisition behavior.  It seems like at some point something changed, and now they are actually keeping their acquisition, but losing their proxying when I reapply the acquisition. 

I can't really explain why or what could be different, so i've tried to write this somewhat defensively so it will do whatever it needs to do, or log errors if it finds something wrong such that the export may not work properly.