### PR TITLE
Memoize _relations to avoid recursive calls at runtime.  This can tak…

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -1101,6 +1101,7 @@ def ModelTypeFactory(name, bases):
 
     @ClassProperty
     @classmethod
+    @memoize
     def _relations(cls):
         """Return _relations property
 


### PR DESCRIPTION
…e a measurable amount of time when calculating getPaths, for instance.