### PR TITLE
Feature/container relationships

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -2548,10 +2548,10 @@ class ClassSpec(Spec):
                 if rspec.remote_classname == spec.name:
                     attr = rel
                     continue
-                
+
             if not attr:
                 attr = container_relationships.get(spec.name, relname_from_classname(spec.name))
-            
+
             attributes[attr] = RelationshipInfoProperty(attr)
 
         for spec in self.inherited_properties().itervalues():
@@ -2751,12 +2751,11 @@ class ClassSpec(Spec):
 
         if self.is_device:
             return fields
-        
+
         filtered_relationships = {}
         for r in self.relationships.values():
             if r.grid_display is False:
                 filtered_relationships[r.remote_classname] = r
-                
         container_relationships = self.get_containing_relations(self)
         for spec in self.containing_components:
             # grid_display=False

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -2476,7 +2476,7 @@ class ClassSpec(Spec):
                 bases = [IInfo]
 
         attributes = {}
-        
+
         for spec in self.inherited_properties().itervalues():
             attributes.update(spec.iinfo_schemas)
 


### PR DESCRIPTION
Added method to handle custom relation names for container components (higher-degree ancestors)

These are otherwise displayed improperly within the component grid and the details pane