### PR TITLE
Initialize CFG in __init__.py for TestCase

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ Release 1.0.11
 Fixes
 
 * Only show Dynamic View for components that support it. (ZEN-22391)
+* Fix created __init__.py to work with zenpacklib.TestCase. (ZEN-22387)
+
 
 Release 1.0.10
 --------------

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -6034,7 +6034,7 @@ def create_zenpack_srcdir(zenpack_name):
     with open(init_fname, 'w') as init_f:
         init_f.write(
             "from . import zenpacklib\n\n"
-            "zenpacklib.load_yaml()\n")
+            "CFG = zenpacklib.load_yaml()\n")
 
     # Create zenpack.yaml in ZenPack module directory.
     yaml_fname = os.path.join(module_directory, 'zenpack.yaml')


### PR DESCRIPTION
zenpacklib.TestCase.afterSetUp() assumes that the ZenPack module will
have a CFG attribute with a value of the ZenPack's ZenPackSpec. The
problem was that running "zenpacklib.py create ..." didn't create
__init__.py properly to make this happen.

This change creates __init__.py in a way that will allow
zenpacklib.TestCase to work.

Fixes ZEN-22387.