### PR TITLE
Guard all getObject() calls agaist damaged ZoDB

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -27,7 +27,7 @@ This module provides a single integration point for common ZenPacks.
 """
 
 # PEP-396 version. (https://www.python.org/dev/peps/pep-0396/)
-__version__ = "1.0.11"
+__version__ = "1.0.12"
 
 
 import logging
@@ -300,8 +300,13 @@ class ZenPack(ZenPackBase):
                 LOG.info('Removing %s components' % self.id)
                 cat = ICatalogTool(app.zport.dmd)
                 for brain in cat.search(types=self.NEW_COMPONENT_TYPES):
-                    component = brain.getObject()
-                    component.getPrimaryParent()._delObject(component.id)
+                    try:
+                        component = brain.getObject()
+                    except Exception as e:
+                        LOG.error("Trying to remove non-existent object %s", e)
+                        continue
+                    else:
+                        component.getPrimaryParent()._delObject(component.id)
 
                 # Remove our Device relations additions.
                 from Products.ZenUtils.Utils import importClass
@@ -622,8 +627,14 @@ class CatalogBase(object):
                 # catalog.
                 results = ICatalogTool(context).search(types=(classname,))
                 for result in results:
-                    if hasattr(result.getObject(), 'index_object'):
-                        result.getObject().index_object()
+                    try:
+                        new_obj = result.getObject()
+                    except Exception as e:
+                        LOG.error("Trying to index non-existent object %s", e)
+                        continue
+                    else:
+                        if hasattr(new_obj, 'index_object'):
+                            new_obj.index_object()
 
     def index_object(self, idxs=None):
         """Index in all configured catalogs."""
@@ -741,8 +752,12 @@ class ComponentBase(ModelBase):
 
         # Find and add new object to relationship.
         for result in catalog_search(self.device(), 'ComponentBase', id=id_):
-            new_obj = result.getObject()
-            relationship.addRelation(new_obj)
+            try:
+                new_obj = result.getObject()
+            except Exception as e:
+                LOG.error("Trying to add relation to non-existent object %s", e)
+            else:
+                relationship.addRelation(new_obj)
 
             # Index remote object. It might have a custom path reporter.
             notify(IndexingEvent(new_obj.primaryAq(), 'path', False))
@@ -785,7 +800,12 @@ class ComponentBase(ModelBase):
 
         obj_map = {}
         for result in catalog_search(self.device(), 'ComponentBase', query):
-            obj_map[result.id] = result.getObject()
+            try:
+                component = result.getObject()
+            except Exception as e:
+                LOG.error("Trying to access non-existent object %s", e)
+            else:
+                obj_map[result.id] = component
 
         for id_ in new_ids.symmetric_difference(current_ids):
             obj = obj_map.get(id_)


### PR DESCRIPTION
Fixes ZEN-22592

Wrap all getObject() calls in try, provide log in case of exception.