### PR TITLE
Fixes modeler timeout issue

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -624,17 +624,21 @@ class CatalogBase(object):
                 # reindex all objects of this type so they are added to the
                 # catalog.
                 results = ICatalogTool(context).search(types=(classname,))
+
+                # global catalog (I think) for removing bad entries
+                #zcat = context.getDmd().global_catalog
+
                 for result in results:
                     try:
                         ob = result.getObject()
                         if hasattr(ob, 'index_object'):
                             ob.index_object()
                     except:
-                        LOG.ERROR('Problem indexing %s' % result.getPath())
+                        LOG.ERROR('Problem indexing bad catalog entry: %s' % result.getPath())
                         # not sure if this is appropriate to do here or not.
                         # but these bad paths didn't show up in dmd.global_catalog
                         # without using ICatalogTool
-                        zcatalog.uncatalog_object(result.getPath())
+                        # zcat.uncatalog_object(result.getPath())
 
     def index_object(self, idxs=None):
         """Index in all configured catalogs."""

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -634,7 +634,7 @@ class CatalogBase(object):
                         if hasattr(ob, 'index_object'):
                             ob.index_object()
                     except:
-                        LOG.ERROR('Problem indexing bad catalog entry: %s' % result.getPath())
+                        LOG.error('Problem indexing bad catalog entry: %s' % result.getPath())
                         # not sure if this is appropriate to do here or not.
                         # but these bad paths didn't show up in dmd.global_catalog
                         # without using ICatalogTool


### PR DESCRIPTION

Affects ZPL-based Zenpacks using indexed component attributes.  In
certain cases the modeler times out due to the following reasons:

1) index scope too wide for catlog objects since ZPL will always choose
'Products.ZenModel.DeviceComponent.DeviceComponent' objects in the
catalog (all components) instead of just objects of the relevant
component class
2) presence of bad catalog brain objects will cause modeler tracebacks
if getObject() fails, which also causes modeler to fail.

- Fixed by narrowing focus of catalog results scope to relevant class
entries
- Added commented code to uncatalog bad entries if appropriate to do so
here