### PR TITLE
Honor value of dynamicview_views class field

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Features
 Documentation
 
 * Fix YAML reference for dynamicview_group class field.
+* Fix documentation of default value for dynamicview_views.
 
 
 Version 1.0

--- a/docs/yaml-classes-and-relationships.rst
+++ b/docs/yaml-classes-and-relationships.rst
@@ -316,7 +316,7 @@ dynamicview_views
   :Description: Names of Dynamic Views objects of this class can appear in.
   :Required: No
   :Type: list<*dynamicview_view_name*>
-  :Default Value: [] *(empty list)*
+  :Default Value: [service_view]
   
 dynamicview_group
   :Description: Dynamic View group name for objects of this class. Can be overridden by implementing getDynamicViewGroup() method on class.

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -2434,6 +2434,7 @@ class ClassSpec(Spec):
             'class_plural_label': self.plural_label,
             'class_short_label': self.short_label,
             'class_plural_short_label': self.plural_short_label,
+            'dynamicview_views': self.dynamicview_views,
             'dynamicview_group': {
                 'name': self.dynamicview_group,
                 'weight': self.dynamicview_weight,
@@ -5956,6 +5957,12 @@ if DYNAMICVIEW_INSTALLED:
             self._adapted = adapted
 
         def getGroup(self, viewName):
+            group = self._adapted
+            entity = group._adapted
+
+            if viewName not in entity.dynamicview_views:
+                return
+
             data = self._adapted.group_data
             if data:
                 return BaseGroup(


### PR DESCRIPTION
Objects were being included in all views regardless of what
dynamicview_views was set to.