### PR TITLE
Revert addition of @memoize to _relations method

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -1131,7 +1131,6 @@ def ModelTypeFactory(name, bases):
 
     @ClassProperty
     @classmethod
-    @memoize
     def _relations(cls):
         """Return _relations property
 


### PR DESCRIPTION
Objects were being included in all views regardless of what
dynamicview_views was set to.

Using @memoize on _relations resulted in incomplete _relations on
classes defined using zenpacklib that extend zenpacklib.Device when
another ZenPack loaded afterwards (via easy-install.pth) monkeypatches
ZenModel.Device._relations. In this case the class defined by zenpacklib
will be missing the monkeypatched relationship.

Specifically I saw this occurring when the Docker ZenPack was installed
after the LinuxMonitor ZenPack. The LinuxDevice class and all instances
of it would not get the docker_containers relationship that the Docker
ZenPack monkeypatches onto ZenModel.Device.

Here's a LinuxDevice's _relations when _relations is not decorated with
@memoize. Note that docker_containers is listed.

    (('dependencies', <Products.ZenRelations.RelSchema.ToMany instance at 0x5b0e908>),
     ('dependents', <Products.ZenRelations.RelSchema.ToMany instance at 0x5b0e9e0>),
     ('componentGroups', <Products.ZenRelations.RelSchema.ToMany instance at 0x5b0ea28>),
     ('maintenanceWindows', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x5b0ea70>),
     ('deviceClass', <Products.ZenRelations.RelSchema.ToOne instance at 0x67de368>),
     ('perfServer', <Products.ZenRelations.RelSchema.ToOne instance at 0x67dec68>),
     ('location', <Products.ZenRelations.RelSchema.ToOne instance at 0x67dee18>),
     ('systems', <Products.ZenRelations.RelSchema.ToMany instance at 0x67e5098>),
     ('groups', <Products.ZenRelations.RelSchema.ToMany instance at 0x67e5320>),
     ('adminRoles', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x67e55f0>),
     ('userCommands', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x67e58c0>),
     ('monitors', <Products.ZenRelations.RelSchema.ToMany instance at 0x67e5998>),
     ('aggregatingPools', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x6a9f5f0>),
     ('docker_containers', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x71c9e18>),
     ('volumeGroups', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x79b2488>),
     ('physicalVolumes', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x79b22d8>),
     ('linuxServices', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x79c53b0>))

Here's the same LinuxDevice's _relations when _relations is decorated with
@memoize. Note that docker_containers is not listed.

    (('dependencies', <Products.ZenRelations.RelSchema.ToMany instance at 0x5baa908>),
     ('dependents', <Products.ZenRelations.RelSchema.ToMany instance at 0x5baa9e0>),
     ('componentGroups', <Products.ZenRelations.RelSchema.ToMany instance at 0x5baaa28>),
     ('maintenanceWindows', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x5baaa70>),
     ('deviceClass', <Products.ZenRelations.RelSchema.ToOne instance at 0x687c368>),
     ('perfServer', <Products.ZenRelations.RelSchema.ToOne instance at 0x687cc68>),
     ('location', <Products.ZenRelations.RelSchema.ToOne instance at 0x687ce18>),
     ('systems', <Products.ZenRelations.RelSchema.ToMany instance at 0x6883098>),
     ('groups', <Products.ZenRelations.RelSchema.ToMany instance at 0x6883320>),
     ('adminRoles', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x68835f0>),
     ('userCommands', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x68838c0>),
     ('monitors', <Products.ZenRelations.RelSchema.ToMany instance at 0x6883998>),
     ('aggregatingPools', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x6b3d5f0>),
     ('volumeGroups', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x7a51dd0>),
     ('physicalVolumes', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x7a51a70>),
     ('linuxServices', <Products.ZenRelations.RelSchema.ToManyCont instance at 0x7a514d0>))