### PR TITLE
Device status is now critical event(s) in /Status

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Features
 * Add overridable getDynamicViewGroup method to generated classes.
 * Class icons beginning with / will be treated as absolute URL paths.
 * Improve performance of entity properties in component grids.
+* Simplify what device status means to critical event(s) in /Status.
 
 Documentation
 

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -114,6 +114,12 @@ from Products.Zuul.utils import ZuulMessageFactory as _t
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 from zope.viewlet.interfaces import IViewlet
 
+from zenoss.protocols.protobufs.zep_pb2 import (
+    STATUS_NEW, STATUS_ACKNOWLEDGED,
+    SEVERITY_CRITICAL,
+    )
+
+
 try:
     import yaml
     import yaml.constructor
@@ -677,6 +683,49 @@ class DeviceBase(ModelBase):
     types.
 
     """
+
+    def getStatus(self, statusclass="/Status", **kwargs):
+        """Return status number for this device.
+
+        The status number is the number of critical events associated
+        with this device. This includes only events tagger with the
+        device's UUID, and not events affecting components of the
+        device.
+
+        None is returned when the device's status is unknown because it
+        isn't being monitored, or because there was an error retrieving
+        its events.
+
+        This method is overridden here to provide a simpler default
+        meaning for "down". By default any critical severity event that
+        is in either the new or acknowledged state in the /Status event
+        class and is tagged with the device's UUID indicates that the
+        device is down. An alternate event class (statusclass) can be
+        provided, which is what would be done by the device's
+        getPingStatus and getSnmpStatus methods.
+
+        A key different between this methods behavior vs. that of the
+        Device.getStatus method it overrides is that warning and error
+        events are not considered as affecting the device's status.
+
+        """
+        if not self.monitorDevice():
+            return None
+
+        zep = Zuul.getFacade("zep", self.dmd)
+        try:
+            event_filter = zep.createEventFilter(
+                tags=[self.getUUID()],
+                element_sub_identifier=[""],
+                severity=[SEVERITY_CRITICAL],
+                status=[STATUS_NEW, STATUS_ACKNOWLEDGED],
+                event_class=filter(None, [statusclass]))
+
+            result = zep.getEventSummaries(0, filter=event_filter, limit=0)
+        except Exception:
+            return None
+
+        return int(result['total'])
 
 
 class ComponentBase(ModelBase):
@@ -2612,9 +2661,15 @@ class ClassSpec(Spec):
             if base_classname in self.zenpack.classes:
                 bases.append(self.zenpack.classes[base_classname].info_class)
 
+        attributes = {}
+
         if not bases:
             if self.is_device:
                 bases = [BaseDeviceInfo]
+
+                # Override how status is determined for devices.
+                attributes["status"] = DeviceInfoStatusProperty()
+
             elif self.is_component:
                 bases = [BaseComponentInfo]
             elif self.is_hardware_component:
@@ -2622,7 +2677,6 @@ class ClassSpec(Spec):
             else:
                 bases = [InfoBase]
 
-        attributes = {}
         attributes.update({
             'class_label': ProxyProperty('class_label'),
             'class_plural_label': ProxyProperty('class_plural_label'),
@@ -5507,6 +5561,15 @@ def relationships_from_yuml(yuml):
             ))
 
     return classes
+
+
+def DeviceInfoStatusProperty():
+    """Return property for DeviceBaseInfo.status."""
+    def getter(self):
+        status = self._object.getStatus()
+        return None if status is None else status < 1
+
+    return property(getter)
 
 
 def MethodInfoProperty(method_name, entity=False):


### PR DESCRIPTION
This seems like the simplest way to think of status that applies to as
many different types of devices as possible. If you want to mark your
device as "down", create a critical severity event for the device in, or
under, the /Status event class.

Devices that are not being monitored because their production state is
less than zProdStateThreshold will still have an unknown status.