### PR TITLE
getRRDTemplateName can return label of base class (Fixes ZEN-19025)

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -1015,7 +1015,7 @@ class ComponentBase(ModelBase):
     def getRRDTemplateName(self):
         """Return name of primary template to bind to this component."""
         if self._templates:
-            return self._templates[0]
+            return self._templates[-1]
 
         return ''
 


### PR DESCRIPTION
- pull last value from _templates in getRRDTemplateName instead of first
value, since this
value is the desired default template in getRRDTemplate method