### PR TITLE
Incorrect display of nested custom-named relations (Fixes ZEN-23995)

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -2468,7 +2468,7 @@ class ClassSpec(Spec):
                 relname = self.find_target_spec_relation(spec_containers.get(direct_name), target)
                 if relname: 
                     return relname
-    return None
+        return None
 
     def is_a(self, type_):
         """Return True if this class is a subclass of type_."""

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -2425,6 +2425,51 @@ class ClassSpec(Spec):
 
         return relationships
 
+    def get_containing_relations(self):
+        """return dictionary of containing component class and relation names"""
+        container_rels = {}
+        # container class name and specs, some of which may be indirect ancestors
+        spec_containers = dict([ (spec.name, spec) for spec in self.containing_components])
+        # remote class and relation names for this spec
+        spec_relations = dict([ (v.remote_classname, v.name) for v in self.relationships.values()])
+        # find container specs that ARE NOT direct ancestors
+        indirect_relations = list(set(spec_containers.keys()).difference(set(spec_relations.keys())))
+        # these are direct ancestors
+        direct_relations = list(set(spec_containers.keys()).intersection(set(spec_relations.keys())))
+        # for direct relations, relname is already known
+        for name in direct_relations:
+            container_rels[name] = spec_relations.get(name)
+        # for indirect relations, relname is in one of the direct relation spec relations
+        for ancestor_name in indirect_relations:
+            container_rels[ancestor_name] = None
+            for direct_name in direct_relations:
+                # no need to keep looking if we find it
+                if container_rels.get(ancestor_name): continue
+                container_rels[ancestor_name] = self.find_target_spec_relation(spec_containers.get(direct_name), ancestor_name)
+            # if this didn't work at all, give up and just use the default ZPL
+            if not container_rels.get(ancestor_name):
+                container_rels[ancestor_name] = relname_from_classname(spec.name)
+        return container_rels
+
+    def find_target_spec_relation(self, spec, target):
+        """recursively search for ancestor relation name for target class"""
+        # remote class and relation names for this spec
+        spec_relations = dict([ (v.remote_classname, v.name) for v in spec.relationships.values()])
+        relname = spec_relations.get(target)
+        if relname:
+            return relname
+        else:
+            # container class name and specs, some of which may be indirect ancestors
+            spec_containers = dict([(spec.name, spec) for spec in spec.containing_components])
+            # find container specs that ARE direct ancestors
+            direct_relations = list(set(spec_containers.keys()).intersection(set(spec_relations.keys())))
+            # otherwise descend among directly related specs
+            for direct_name in direct_relations:
+                relname = self.find_target_spec_relation(spec_containers.get(direct_name), target)
+                if relname: 
+                    return relname
+    return None
+
     def is_a(self, type_):
         """Return True if this class is a subclass of type_."""
         return issubclass(self.model_schema_class, type_)
@@ -2621,8 +2666,10 @@ class ClassSpec(Spec):
         for spec in self.inherited_properties().itervalues():
             attributes.update(spec.iinfo_schemas)
 
+        container_relationships = self.get_containing_relations()
+
         for i, spec in enumerate(self.containing_components):
-            attr = relname_from_classname(spec.name)
+            attr = container_relationships.get(spec.name)
             attributes[attr] = schema.Entity(
                 title=_t(spec.label),
                 group="Relationships",
@@ -2684,16 +2731,10 @@ class ClassSpec(Spec):
             'class_plural_short_label': ProxyProperty('class_plural_short_label')
         })
 
+        container_relationships = self.get_containing_relations()
+
         for spec in self.containing_components:
-            attr = None
-            for rel, rspec in self.relationships.items():
-                if rspec.remote_classname == spec.name:
-                    attr = rel
-                    continue
-
-            if not attr:
-                attr = relname_from_classname(spec.name)
-
+            attr = container_relationships.get(spec.name)
             attributes[attr] = RelationshipInfoProperty(attr)
 
         for spec in self.inherited_properties().itervalues():
@@ -2867,6 +2908,8 @@ class ClassSpec(Spec):
             if r.grid_display is False:
                 filtered_relationships[r.remote_classname] = r
 
+        container_relationships = self.get_containing_relations()
+
         for spec in self.containing_components:
             # grid_display=False
             if spec.name in filtered_relationships:
@@ -2874,7 +2917,7 @@ class ClassSpec(Spec):
             fields.append(
                 "{{name: '{}'}}"
                 .format(
-                    relname_from_classname(spec.name)))
+                    container_relationships.get(spec.name)))
 
         return fields
 
@@ -2891,6 +2934,8 @@ class ClassSpec(Spec):
             if r.grid_display is False:
                 filtered_relationships[r.remote_classname] = r
 
+        container_relationships = self.get_containing_relations()
+
         for spec in self.containing_components:
             # grid_display=False
             if spec.name in filtered_relationships:
@@ -2902,7 +2947,7 @@ class ClassSpec(Spec):
 
             column_fields = [
                 "id: '{}'".format(spec.name),
-                "dataIndex: '{}'".format(relname_from_classname(spec.name)),
+                "dataIndex: '{}'".format(container_relationships.get(spec.name)),
                 "header: _t('{}')".format(spec.short_label),
                 "width: {}".format(width),
                 "renderer: {}".format(renderer),


### PR DESCRIPTION
- Fixes ZEN-24302
- required for correct display in vSphere, HP Proliant, Azure, and other ZPs with custom relationship names
- Added method to handle custom relation names for nested components
- These are otherwise displayed improperly within the component grid and
the details pane