### PR TITLE
Ensure non-cached datapoints return current value

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,14 @@
 Version 1.0
 ===========
 
+Release 1.0.14
+--------------
+
+Fixes
+
+* Ensure non-cached datapoints return current value. (ZEN-22288)
+
+
 Release 1.0.13
 --------------
 

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -2448,8 +2448,10 @@ class ClassSpec(Spec):
                     if cached:
                         r = self.cacheRRDValue(datapoint, default=default)
                     else:
-                        r = self.getRRDValue(datapoint, default=default)
-
+                        if is_pre_zenoss_5():
+                            r = self.getRRDValue(datapoint, start=time.time()-1800)
+                        else:
+                            r = self.getRRDValue(datapoint)
                     if r is not None:
                         if not math.isnan(float(r)):
                             return r
@@ -5609,6 +5611,15 @@ OrderAndValue = collections.namedtuple('OrderAndValue', ['order', 'value'])
 
 
 # Private Functions #########################################################
+
+def is_pre_zenoss_5():
+    '''return True if Zenoss is version 4.x or below'''
+    from Products.ZenModel.ZVersion import VERSION
+    from Products.ZenUtils.Version import Version
+    if Version.parse('Zenoss %s' % VERSION) < Version.parse('Zenoss 5'):
+        return True
+    return False
+
 
 def get_zenpack_path(zenpack_name):
     """Return filesystem path for given ZenPack."""

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -114,6 +114,13 @@ from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 from zope.viewlet.interfaces import IViewlet
 
 try:
+    from Products.Zuul.facades import metricfacade  # noqa: imported only to test that it can be imported
+except ImportError:
+    HAS_METRICFACADE = False
+else:
+    HAS_METRICFACADE = True
+
+try:
     import yaml
     import yaml.constructor
     YAML_INSTALLED = True
@@ -2448,10 +2455,11 @@ class ClassSpec(Spec):
                     if cached:
                         r = self.cacheRRDValue(datapoint, default=default)
                     else:
-                        if is_pre_zenoss_5():
-                            r = self.getRRDValue(datapoint, start=time.time()-1800)
-                        else:
+                        if HAS_METRICFACADE:
                             r = self.getRRDValue(datapoint)
+                        else:
+                            r = self.getRRDValue(datapoint, start=time.time()-1800)
+
                     if r is not None:
                         if not math.isnan(float(r)):
                             return r
@@ -5611,15 +5619,6 @@ OrderAndValue = collections.namedtuple('OrderAndValue', ['order', 'value'])
 
 
 # Private Functions #########################################################
-
-def is_pre_zenoss_5():
-    '''return True if Zenoss is version 4.x or below'''
-    from Products.ZenModel.ZVersion import VERSION
-    from Products.ZenUtils.Version import Version
-    if Version.parse('Zenoss %s' % VERSION) < Version.parse('Zenoss 5'):
-        return True
-    return False
-
 
 def get_zenpack_path(zenpack_name):
     """Return filesystem path for given ZenPack."""


### PR DESCRIPTION
- Fixes ZEN-22288
- adds platform version detection function
- adds "start" parameter to getRRDValue call, which ensures that
'current' metric on graph is reflected in property
- "start" parameter used in applies to Zenoss 4.x and below only