### PR TITLE
prevent relationship schema from overwriting if duplicate names used

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -1625,7 +1625,8 @@ class ZenPackSpec(Spec):
 
                     # make sure we have the schema defined
                     if target_relname in class_.relationships:
-                        class_.relationships[target_relname].schema = target_schema
+                         if not class_.relationships[target_relname].schema:
+                             class_.relationships[target_relname].schema = target_schema
 
             # Plumb _relations
             for relname, relationship in class_.relationships.iteritems():

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -1625,8 +1625,8 @@ class ZenPackSpec(Spec):
 
                     # make sure we have the schema defined
                     if target_relname in class_.relationships:
-                         if not class_.relationships[target_relname].schema:
-                             class_.relationships[target_relname].schema = target_schema
+                        if not class_.relationships[target_relname].schema:
+                            class_.relationships[target_relname].schema = target_schema
 
             # Plumb _relations
             for relname, relationship in class_.relationships.iteritems():


### PR DESCRIPTION
- fixes bug introduced by PR 182 (ZEN-23763)
- HP Proliant relations are an example case