### PR TITLE
Ensure that 'extra_params' get applied to template-related objects (ZenPack)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
@@ -31,7 +31,7 @@ from ..helpers.Loader import Loader
 class ZPLCommand(ZenScriptBase):
     '''ZPLCommand'''
     
-    def __init__(self, noopts=0, app=None, connect=True, version=None):
+    def __init__(self, noopts=0, app=None, connect=False, version=None):
         ''''''
         if not version:
             from ZenPacks.zenoss.ZenPackLib import zenpacklib

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -50,7 +50,7 @@ class RRDTemplateSpec(Spec):
         self.graphs = self.specs_from_param(
             GraphDefinitionSpec, 'graphs', graphs)
 
-    def create(self, dmd):
+    def create(self, dmd, addToZenPack=True):
         device_class = dmd.Devices.createOrganizer(self.deviceclass_spec.path)
 
         existing_template = device_class.rrdTemplates._getOb(self.name, None)
@@ -65,9 +65,11 @@ class RRDTemplateSpec(Spec):
         # exported to objects.xml  (contained objects will also be excluded)
         template.zpl_managed = True
 
-        # Add this RRDTemplate to the zenpack.
-        zenpack_name = self.deviceclass_spec.zenpack_spec.name
-        template.addToZenPack(pack=zenpack_name)
+        # set to false to facilitate testing without ZP installation
+        if addToZenPack:
+            # Add this RRDTemplate to the zenpack.
+            zenpack_name = self.deviceclass_spec.zenpack_spec.name
+            template.addToZenPack(pack=zenpack_name)
 
         if not existing_template:
             self.speclog.info("adding template")
@@ -89,3 +91,5 @@ class RRDTemplateSpec(Spec):
         for i, (graph_id, graph_spec) in enumerate(self.graphs.items()):
             graph_spec.create(self, template, sequence=i)
 
+        if not addToZenPack:
+            return template

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -186,7 +186,11 @@ class Spec(object):
             for k, v in dictionary.iteritems():
                 dictionary[k] = dict(defaults, **v)
                 if 'extra_params' in  dictionary[k].keys():
-                    dictionary[k]['extra_params'].update(defaults.get('extra_params',{}))
+                    extra_params = defaults.get('extra_params',{})
+                    dictionary_params = dictionary[k]['extra_params']
+                    for i, j in extra_params.items():
+                        if i not in dictionary_params.keys():
+                            dictionary_params[i] = j
 
     def specs_from_param(self, spec_type, param_name, param_dict, apply_defaults=True, leave_defaults=False):
         """Return a normalized dictionary of spec_type instances."""

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -185,6 +185,8 @@ class Spec(object):
                 defaults = dictionary.pop('DEFAULTS')
             for k, v in dictionary.iteritems():
                 dictionary[k] = dict(defaults, **v)
+                if 'extra_params' in  dictionary[k].keys():
+                    dictionary[k]['extra_params'].update(defaults.get('extra_params',{}))
 
     def specs_from_param(self, spec_type, param_name, param_dict, apply_defaults=True, leave_defaults=False):
         """Return a normalized dictionary of spec_type instances."""

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -185,7 +185,7 @@ class Spec(object):
                 defaults = dictionary.pop('DEFAULTS')
             for k, v in dictionary.iteritems():
                 dictionary[k] = dict(defaults, **v)
-                if 'extra_params' in  dictionary[k].keys():
+                if 'extra_params' in dictionary[k].keys():
                     extra_params = defaults.get('extra_params',{})
                     dictionary_params = dictionary[k]['extra_params']
                     for i, j in extra_params.items():

--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
@@ -1,4 +1,5 @@
 import inspect
+import yaml
 from Products.ZenRelations.Exceptions import RelationshipExistsError
 import logging
 logging.basicConfig(level=logging.INFO)
@@ -6,12 +7,22 @@ log = logging.getLogger('zen.zenpacklib.tests')
 
 from ZenPacks.zenoss.ZenPackLib import zenpacklib
 
+import Globals
+from Products.ZenUtils.Utils import unused
+unused(Globals)
 
-class ZPLTestHarness(object):
+from Products.ZenUtils.ZenScriptBase import ZenScriptBase
+
+
+class ZPLTestHarness(ZenScriptBase):
     '''Class containing methods to build out dummy objects representing YAML class instances'''
 
-    def __init__(self, filename):
-        self.cfg = zenpacklib.load_yaml(filename)
+    def __init__(self, filename, connect=False):
+        ''''''
+        ZenScriptBase.__init__(self)
+        self.filename = filename
+        self.cfg = zenpacklib.load_yaml(self.filename)
+        self.yaml = yaml.load(open(self.filename, 'r'))
         self.zp = self.cfg.zenpack_module
         self.schema = self.zp.schema
         self.build_cfg_obs()
@@ -265,6 +276,117 @@ class ZPLTestHarness(object):
             # check for intended versus actual type
             if intended_type != actual_type:
                 print '%s (%s) type mismatch spec (%s) vs class (%s)'% (cls_id, name, intended_type, actual_type)
+                passed = False
+        return passed
+
+    def check_templates_vs_specs(self):
+        '''check that template objects match the specs'''
+        self.connect()
+        passed = True
+        for dcid, dcs in self.cfg.device_classes.items():
+            for tid, tcs in dcs.templates.items():
+                # create a dummy template object
+                t = tcs.create(self.dmd, False)
+                print t.id, '-' * 80
+                for th in t.thresholds():
+                    thcs = tcs.thresholds.get(th.id)
+                    test, msg = self.compare_template_ob_to_spec(th, thcs)
+                    if not test:
+                        print '%s threshold %s failed (%s)' % (t.id, th.id, msg)
+                        passed = False
+                for gd in t.graphDefs():
+                    gdcs = tcs.graphs.get(gd.id)
+                    test, msg = self.compare_template_ob_to_spec(gd, gdcs)
+                    if not test:
+                        print '%s graph %s failed (%s)' % (t.id, gd.id, msg)
+                        passed = False
+                for ds in t.datasources():
+                    dscs = tcs.datasources.get(ds.id)
+                    test, msg = self.compare_template_ob_to_spec(ds, dscs)
+                    if not test:
+                        print '%s datasource %s failed (%s)' % (t.id, ds.id, msg)
+                        passed = False
+                    for dp in ds.datapoints():
+                        dpcs = dscs.datapoints.get(dp.id)
+                        test, msg = self.compare_template_ob_to_spec(dp, dpcs)
+                        if not test:
+                            print '%s %s datapoint %s failed (%s)' % (t.id, ds.id, dp.id, msg)
+                            passed = False
+        return passed
+
+    def compare_template_to_spec(self, template, spec):
+        '''compare template to spec'''
+        if template.id != spec.name:
+            return False
+        if template.description != spec.description:
+            return False
+        if tcs.targetPythonClass:
+            if tcs.targetPythonClass != t.targetPythonClass:
+                return False
+        return True
+
+    def compare_template_ob_to_spec(self, ob, dscs):
+        '''compare template object to spec'''
+        passed = True
+        cls = self.classname(ob)
+        msg = '%s passed inspection' % cls
+        for p in ob._properties:
+            id = p.get('id')
+            default = getattr(ob, id)
+            spec_default = getattr(dscs, id, getattr(dscs,'extra_params',{}).get(id))
+            # skip if not defined:
+            if not spec_default:
+                continue
+            print "comparing %s %s (%s) to %s (%s)" % (id, default, type(default), spec_default, type(spec_default))
+            if default != spec_default:
+                msg = '%s property %s mismatch between class (%s) and spec (%s)  and default' % (ob.id, id, default, spec_default)
+                passed = False
+        return (passed, msg)
+
+    def check_templates_vs_yaml(self):
+        '''check that template objects match the yaml'''
+        self.connect()
+        passed = True
+        for dcid, dcs in self.cfg.device_classes.items():
+            # get data from unparsed, loaded yaml
+            y_dcs = self.yaml.get('device_classes').get(dcid)
+            y_templates = y_dcs.get('templates')
+            for tid, tcs in dcs.templates.items():
+                y_t = y_templates.get(tid)
+                # create a dummy template object
+                t = tcs.create(self.dmd, False)
+                if not self.check_ob_vs_yaml(t, y_templates):
+                    passed = False
+                for ds in t.datasources():
+                    y_ds = y_t.get('datasources').get(ds.id)
+                    if not self.check_ob_vs_yaml(ds, y_t.get('datasources')):
+                        passed = False
+                    for dp in ds.datapoints():
+                        if not self.check_ob_vs_yaml(dp, y_ds.get('datapoints')):
+                            passed = False
+                for th in t.thresholds():
+                    if not self.check_ob_vs_yaml(th, y_t.get('thresholds')):
+                        import pdb ; pdb.set_trace()
+                        passed = False
+                for gd in t.graphDefs():
+                    if not self.check_ob_vs_yaml(gd, y_t.get('graphs')):
+                        passed = False
+        return passed
+
+    def check_ob_vs_yaml(self, ob, data):
+        '''compare object values to YAML'''
+        passed = True
+        ob_data = data.get(ob.id)
+        ob_data.update(data.get('DEFAULTS',{}))
+        for k, v in ob_data.items():
+            if isinstance(v, dict):
+                continue
+            if k == 'type':
+                k = 'sourcetype'
+            expected = v
+            actual = getattr(ob, k)
+            if expected != actual:
+                print '%s (%s) property %s: acutal (%s) did not match expected (%s)' % (ob.id, ob.meta_type, k, actual, expected)
                 passed = False
         return passed
 

--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
@@ -1,4 +1,3 @@
-import inspect
 import yaml
 from Products.ZenRelations.Exceptions import RelationshipExistsError
 import logging
@@ -132,7 +131,7 @@ class ZPLTestHarness(ZenScriptBase):
 
     def is_device(self, ob):
         '''return True if device'''
-        if hasattr(d, 'deviceClass'):
+        if hasattr(ob, 'deviceClass'):
             return True
         return False
 
@@ -179,11 +178,11 @@ class ZPLTestHarness(ZenScriptBase):
         spec_s_from = self.classname(rspec.left_schema)
         spec_s_to = self.classname(rspec.right_schema)
         # checking classes
-        if cls_from != spec_from:# and spec_from not in bases_from:
+        if cls_from != spec_from and spec_from not in bases_from:
             print self.rel_spec_info(rspec)
             print 'Remote left class mismatch between spec (%s) and relation (%s)' % (spec_from, cls_from)
             return False
-        if cls_to != spec_to: # and spec_to not in bases_to:
+        if cls_to != spec_to and spec_to not in bases_to:
             print self.rel_spec_info(rspec)
             print 'Remote right class mismatch between spec (%s) and relation (%s)' % (spec_to, cls_to)
             return False

--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
@@ -20,9 +20,8 @@ class ZPLTestHarness(ZenScriptBase):
     def __init__(self, filename, connect=False):
         ''''''
         ZenScriptBase.__init__(self)
-        self.filename = filename
-        self.cfg = zenpacklib.load_yaml(self.filename)
-        self.yaml = yaml.load(open(self.filename, 'r'))
+        self.cfg = zenpacklib.load_yaml(filename)
+        self.yaml = yaml.load(open(filename, 'r'))
         self.zp = self.cfg.zenpack_module
         self.schema = self.zp.schema
         self.build_cfg_obs()

--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
@@ -319,8 +319,8 @@ class ZPLTestHarness(ZenScriptBase):
             return False
         if template.description != spec.description:
             return False
-        if tcs.targetPythonClass:
-            if tcs.targetPythonClass != t.targetPythonClass:
+        if spec.targetPythonClass:
+            if spec.targetPythonClass != template.targetPythonClass:
                 return False
         return True
 

--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
@@ -365,7 +365,6 @@ class ZPLTestHarness(ZenScriptBase):
                             passed = False
                 for th in t.thresholds():
                     if not self.check_ob_vs_yaml(th, y_t.get('thresholds')):
-                        import pdb ; pdb.set_trace()
                         passed = False
                 for gd in t.graphDefs():
                     if not self.check_ob_vs_yaml(gd, y_t.get('graphs')):

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-24083.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-24083.yaml
@@ -1,0 +1,79 @@
+name: ZenPacks.community.TestDEFAULSonDatasource
+
+device_classes:
+  /Device:
+    templates:
+      TESTAGGPASS:
+        description: you should see that targetDatsource sets correctly
+        datasources:
+          # THESE defaults arent working so set manually below remove when fixed
+          DEFAULTS:
+            type: Datapoint Aggregator
+            eventClass: /App/Zenoss
+            component: "${here/id}"
+          agg_out_octets:
+            type: Datapoint Aggregator
+            targetDataSource: ethernetcmascd_64
+            targetDataPoint: ifHCOutOctets
+            targetMethod: os.interfaces
+            datapoints:
+              aggifHCOutOctets:
+                operation: sum
+          agg_in_octets:
+            type: Datapoint Aggregator
+            targetDataSource: ethernetcmascd_64
+            targetDataPoint: ifHCInOctets
+            targetMethod: os.interfaces
+            datapoints:
+              aggifHCInOctets:
+                operation: sum
+        graphs:
+          DEFAULTS:
+            width: 1000
+            miny: -100
+            maxy: 100
+            units: oct per sec
+          Aggregated Octets:
+            graphpoints:
+              RX:
+                dpName: agg_out_octets_aggifHCOutOctets
+              TX:
+                dpName: agg_in_octets_aggifHCInOctets
+
+      TESTAGGFAIL:
+        description: you should see that targetDatsource does not set
+        datasources:
+          # THESE defaults arent working so set manually below remove when fixed
+          DEFAULTS:
+            type: Datapoint Aggregator
+            eventClass: /App/Zenoss
+            component: "${here/id}"
+            targetDataSource: ethernetcmascd_64
+            targetDataPoint: ifHCOutOctets
+            targetMethod: os.interfaces
+          agg_out_octets:
+            datapoints:
+              aggifHCOutOctets:
+                operation: sum
+          agg_in_octets:
+            datapoints:
+              aggifHCInOctets:
+                operation: sum
+        thresholds:
+          TEST:
+            dsnames: [agg_out_octets_aggifHCOutOctets]
+            eventClass: /Perf
+            severity: crit
+            minval: -100
+            maxval: 100
+        graphs:
+          DEFAULTS:
+            width: 1000
+            miny: 0
+            units: oct per sec
+          Aggregated Octets:
+            graphpoints:
+              RX:
+                dpName: agg_out_octets_aggifHCOutOctets
+              TX:
+                dpName: agg_in_octets_aggifHCInOctets

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_classes.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_classes.py
@@ -31,27 +31,6 @@ from .ZPLTestHarness import ZPLTestHarness
 import Globals  # noqa
 
 
-dynamicview_js = '''Zenoss.nav.appendTo('Component', [{
-    id: 'subcomponent_view',
-    text: _t('Dynamic View'),
-    xtype: 'dynamicview',
-    relationshipFilter: 'impacted_by',
-    viewName: 'service_view',
-    filterNav: function(navpanel) {
-        switch (navpanel.refOwner.componentType) {
-'''
-
-ibm_component = '''ZC.LogicalPartitionsPanel = Ext.extend(ZC.ZPL_ZenPacks_zenoss_IBM_Power_ComponentGridPanel, {    constructor: function(config) {
-        config = Ext.applyIf(config||{}, {
-            componentType: 'LogicalPartitions',
-            autoExpandColumn: 'name',
-            fields: [{name: 'uid'},{name: 'name'},{name: 'meta_type'},{name: 'class_label'},{name: 'status'},{name: 'severity'},{name: 'usesMonitorAttribute'},{name: 'monitame: 'locking'},{name: 'hmcserver'},{name: 'getManagedSystemStatusText'},{name: 'managedSystem'}],
-            columns: [{id: 'severity',dataIndex: 'severity',header: _t('Events'),renderer: Zenoss.render.severity,width: 50},{id: 'name',dataIndex: 'name',header: _t('Name'r: Zenoss.render.zenpacklib_ZenPacks_zenoss_IBM_Power_entityLinkFromGrid},{id: 'HMCServer',dataIndex: 'hmcserver',header: _t('HMC Server'),width: 100,renderer: Zenoss.rendelib_ZenPacks_zenoss_IBM_Power_entityLinkFromGrid},{id: 'managedSystem',dataIndex: 'managedSystem',header: _t('Managed System'),width: 100,renderer: Zenoss.render.zenpacklib_zenoss_IBM_Power_entityLinkFromGrid},{id: 'getManagedSystemStatusText',dataIndex: 'getManagedSystemStatusText',header: _t('Managed System Status'),width: 130},{id: 'monitoIndex: 'monitored',header: _t('Monitored'),renderer: Zenoss.render.checkbox,width: 70},{id: 'locking',dataIndex: 'locking',header: _t('Locking'),renderer: Zenoss.render.locs,width: 65}]
-        });
-        ZC.LogicalPartitionsPanel.superclass.constructor.call(this, config);
-    }
-});
-'''
 
 class TestClasses(unittest.TestCase):
 
@@ -63,9 +42,7 @@ class TestClasses(unittest.TestCase):
         for f in os.listdir(fdir):
             if '.yaml' not in f:
                 continue
-        #for file in ['ms_windows.yaml', 'bigipmonitor.yaml', 'ibm_power.yaml', 'hp_proliant.yaml']:
             file = os.path.join(os.path.dirname(__file__), 'data/yaml/%s' % f)
-            print "LOADING FILE: %s" % file
             log.info("loading file: %s" % file)
             self.zps.append(ZPLTestHarness(file))
 
@@ -85,21 +62,21 @@ class TestClasses(unittest.TestCase):
         for zp in self.zps:
             self.assertTrue(zp.check_cfg_relations(),"Test Failed")
 
-#     def test_DynamicViewComponentNav(self):
-#         
-#         for zp in self.zps:
-#             # dynamicview_nav_js_snippet is only used internally by zenpacklib, but
-#             # it should match exactly and be an easier test to make.
-#             self.assertMultiLineEqual(
-#                 zp.cfg.dynamicview_nav_js_snippet.strip(),
-#                 dynamicview_js.strip())
-# 
-#             # device_js_snippet is actually used to create the JavaScript snippet,
-#             # and should contain our subcomponent_view among many other things.
-# #             self.assertIn(
-# #                 EXPECTED_SUBCOMPONENT_VIEW.strip(),
-# #                 zenpack.device_js_snippet.strip())
+    def test_Templates_YAML(self):
+        '''
+        check that class relations follow the spec
+        '''
+        log.info("Checking relations")
+        for zp in self.zps:
+            self.assertTrue(zp.check_templates_vs_yaml(),"Test Failed")
 
+    def test_Templates_Spec(self):
+        '''
+        check that class relations follow the spec
+        '''
+        log.info("Checking relations")
+        for zp in self.zps:
+            self.assertTrue(zp.check_templates_vs_specs(),"Test Failed")
 
 def test_suite():
     """Return test suite for this module."""


### PR DESCRIPTION
Fixes ZEN-24083

- update 'apply_data_defaults' to explicitly update 'extra_params' from DEFAULTS if not explicitly set
- updated ZenPackSpec to allow examination of template objects in memory
- added methods to TestHarness to compare tempate-related objects to specs and yaml
- updated unit tests to validate templates vs. specs and vs. yaml
- removed unused code from test_classes.py
- change ZPLCommand default connect parameter to False