### PR TITLE
Check for reserved keywords from python, Device, Component

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Features
 * Class icons beginning with / will be treated as absolute URL paths.
 * Improve performance of entity properties in component grids.
 * Simplify what device status means to critical event(s) in /Status.
+* Add detection of reserved words
 
 Fixes
 * Fix tracebacks caused by property datapoint_cached. (ZEN-22287)

--- a/tests/BaseTestCommand.py
+++ b/tests/BaseTestCommand.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Command unit tests.
+
+This module tests command line usage of zenpacklib.py.
+
+"""
+
+import logging
+import subprocess
+import os
+import Globals
+from Products.ZenUtils.Utils import unused
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+unused(Globals)
+
+logging.basicConfig(level=logging.INFO)
+LOG = logging.getLogger('zen.zenpacklib.tests')
+
+
+class BaseTestCommand(BaseTestCase):
+
+    zenpacklib_path = os.path.join(os.path.dirname(__file__),
+                                   "../zenpacklib.py")
+
+    def _smoke_command(self, *args):
+        cmd = (self.zenpacklib_path,) + args
+        cmdstr = " ".join(cmd)
+
+        LOG.info("Running %s" % cmdstr)
+        p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        out, err = p.communicate()
+        p.wait()
+        LOG.debug("Stdout: %s\nStderr: %s", out, err)
+
+        self.assertIs(p.returncode, 0,
+                      'Error running %s: %s%s' % (cmdstr, err, out))
+
+        if out is not None:
+            self.assertNotIn("Error", out)
+            self.assertNotIn("Error", out)
+        if err is not None:
+            self.assertNotIn("Traceback", err)
+            self.assertNotIn("Traceback", err)
+
+        return out

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -29,14 +29,14 @@ LOG = logging.getLogger('zen.zenpacklib.tests')
 
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 
+from .BaseTestCommand import BaseTestCommand
 
-class TestCommands(BaseTestCase):
+
+class TestCommands(BaseTestCommand):
 
     zenpack_name = 'ZenPacks.zenoss.ZPLTest1'
     zenpack_path = os.path.join(os.path.dirname(__file__),
                                 "data/zenpacks/ZenPacks.zenoss.ZPLTest1")
-    zenpacklib_path = os.path.join(os.path.dirname(__file__),
-                                   "../zenpacklib.py")
     yaml_path = os.path.join(zenpack_path, 'ZenPacks/zenoss/ZPLTest1/zenpack.yaml')
 
     disableLogging = False
@@ -49,28 +49,6 @@ class TestCommands(BaseTestCase):
                 e.message == 'No module named ZPLTest1',
                 "ZPLTest1 zenpack is not installed.  You must install it before running this test:\n   zenpack --link --install=%s" % self.zenpack_path
             )
-
-    def _smoke_command(self, *args):
-        cmd = (self.zenpacklib_path,) + args
-        cmdstr = " ".join(cmd)
-
-        LOG.info("Running %s" % cmdstr)
-        p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-        out, err = p.communicate()
-        p.wait()
-        LOG.debug("Stdout: %s\nStderr: %s", out, err)
-
-        self.assertIs(p.returncode, 0,
-                      'Error running %s: %s%s' % (cmdstr, err, out))
-
-        if out is not None:
-            self.assertNotIn("Error", out)
-            self.assertNotIn("Error", out)
-        if err is not None:
-            self.assertNotIn("Traceback", err)
-            self.assertNotIn("Traceback", err)
-
-        return out
 
     def test_smoke_lint(self):
         self._smoke_command("lint", self.yaml_path)

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Keyword Tests
+This test will use lint to load in example yaml with keywords used
+"""
+# stdlib Imports
+import tempfile
+import logging
+
+# Zenoss Imports
+import Globals  # noqa
+
+from Products.ZenUtils.Utils import unused
+from BaseTestCommand import BaseTestCommand
+
+unused(Globals)
+log = logging.getLogger('zen.zenpacklib.tests')
+
+RESERVED_YAML = """name: ZenPacks.zenoss.Example
+
+classes:
+    ExampleDevice:
+        base: [zenpacklib.Device]
+        label: Example
+        properties:
+            uuid:
+                label: UUID
+            yield:
+                label: Yield
+    lambda:
+        base: [zenpacklib.Component]
+        label: Lambda
+        properties:
+            prop1:
+                label: yield
+
+device_classes:
+    /Server/SSH:
+        templates:
+            breadCrumbs:
+                description: Poorly named template
+
+                datasources:
+                    health:
+                        type: COMMAND
+                        parser: Nagios
+                        commandTemplate: "echo OK|percent=100"
+
+                        datapoints:
+                          percent:
+                            rrdtype: GAUGE
+                            rrdmin: 0
+                            rrdmax: 100
+
+"""
+NO_RESERVED_YAML = """name: ZenPacks.zenoss.Example
+
+classes:
+    ExampleDevice:
+        base: [zenpacklib.Device]
+        label: Example
+        properties:
+            prop1:
+                label: Example Property
+    ProperComponent:
+        base: [zenpacklib.Component]
+        label: Properly Named Component
+        properties:
+            prop1:
+                label: Property One
+"""
+
+
+class TestKeywords(BaseTestCommand):
+
+    def test_reserved_keywords(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(RESERVED_YAML.strip())
+            f.flush()
+            out = self._smoke_command('lint', f.name).split('\n')
+            log.debug('Lint results: {}'.format(out))
+            self.assertEquals(5, len(out))
+            self.assertIn("Found reserved keyword 'uuid'", out[0])
+            self.assertIn("Found reserved keyword 'yield'", out[1])
+            self.assertIn("Found reserved keyword 'lambda'", out[2])
+            self.assertIn("Found reserved keyword 'breadCrumbs'", out[3])
+
+            f.close()
+
+    def test_no_reserved_keywords(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(NO_RESERVED_YAML.strip())
+            f.flush()
+            out = self._smoke_command('lint', f.name)
+            self.assertEquals('', out)
+            f.close()
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestKeywords))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -167,9 +167,18 @@ TestCase = None
 # Required for registering ZCSA adapters.
 GSM = getGlobalSiteManager()
 
-# Use OTHERS for any other words we shouldn't use
-OTHERS = ['uuid', ]
-KEYWORDS = keyword.kwlist + list(set(dir(BaseDevice)).union(set(dir(BaseDeviceComponent)))) + OTHERS
+
+def getZenossKeywords(klasses):
+    kwset = set()
+    for klass in klasses:
+        kwset = kwset.union(set(dir(klass)))
+    return list(kwset)
+
+ZENOSS_KEYWORDS = getZenossKeywords([BaseDevice,
+                                     BaseDeviceComponent,
+                                     BaseDeviceInfo,
+                                     BaseComponentInfo])
+KEYWORDS = keyword.kwlist + ZENOSS_KEYWORDS
 
 
 # Public Classes ############################################################

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -49,6 +49,7 @@ import re
 import sys
 import math
 import types
+import keyword
 
 from lxml import etree
 
@@ -165,6 +166,10 @@ TestCase = None
 
 # Required for registering ZCSA adapters.
 GSM = getGlobalSiteManager()
+
+# Use OTHERS for any other words we shouldn't use
+OTHERS = ['uuid', ]
+KEYWORDS = keyword.kwlist + list(set(dir(BaseDevice)).union(set(dir(BaseDeviceComponent)))) + OTHERS
 
 
 # Public Classes ############################################################
@@ -4907,6 +4912,12 @@ if YAML_INSTALLED:
         for spec_key_node, spec_value_node in node.value:
             try:
                 spec_key = str(loader.construct_scalar(spec_key_node))
+                if spec_key in KEYWORDS:
+                    yaml_error(loader, yaml.constructor.ConstructorError(
+                        None, None,
+                        "Found reserved keyword '{}' while processing {}".format(spec_key, spec_class.__name__),
+                        spec_key_node.start_mark))
+                    continue
             except yaml.MarkedYAMLError, e:
                 yaml_error(loader, e)
 
@@ -5127,6 +5138,12 @@ if YAML_INSTALLED:
         for key_node, value_node in node.value:
             yaml_key = str(loader.construct_scalar(key_node))
 
+            if yaml_key in KEYWORDS and yaml_key != 'name':
+                yaml_error(loader, yaml.constructor.ConstructorError(
+                    None, None,
+                    "Found reserved keyword '{}' while processing {}".format(yaml_key, cls.__name__),
+                    key_node.start_mark))
+                continue
             if yaml_key not in param_name_map:
                 if extra_params:
                     # If an 'extra_params' parameter is defined for this spec,


### PR DESCRIPTION
Fixes ZEN-19460

This will load in methods/properties from Device, Component, and
python reserved keywords and test for them.  Added another list
for any future keywords for which we should look.  Unit test checks
one yaml that is properly named and one that is using reserved words.