### PR TITLE
implement data type checking for extra_params when loading from YAML (ZENPACK)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/functions.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/functions.py
@@ -755,7 +755,7 @@ def type_map(loader, node):
                 return map.get(k,'str')(node.value)
             except:
                 pass
-    return loader.construct_shorthand(node)
+    return loader.construct_scalar(node)
 
 
 def construct_spec(cls, loader, node):

--- a/ZenPacks/zenoss/ZenPackLib/lib/functions.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/functions.py
@@ -736,6 +736,28 @@ def represent_spec(dumper, obj, yaml_tag=u'tag:yaml.org,2002:map', defaults=None
     return node
 
 
+def type_map(loader, node):
+    '''map yaml node to python data type'''
+    map = {'int': int,
+           'float': float, 
+           'str': str,
+           'unicode': unicode,
+           'bool': bool,
+           'binary': str,
+           'set': set,
+           'seq': list,
+           'map': dict}
+    if 'null' in node.tag:
+        return None
+    for k in map.keys():
+        if k in node.tag:
+            try:
+                return map.get(k,'str')(node.value)
+            except:
+                pass
+    return loader.construct_shorthand(node)
+
+
 def construct_spec(cls, loader, node):
     """
     Generic constructor for deserializing specs from YAML.   Should be
@@ -789,7 +811,7 @@ def construct_spec(cls, loader, node):
                 #
                 # Note that the values of these extra parameters need to be
                 # scalars, not nested maps or something like that.
-                params[extra_params][yaml_key] = loader.construct_scalar(value_node)
+                params[extra_params][yaml_key] = type_map(loader, value_node)
                 continue
             else:
                 yaml_error(loader, yaml.constructor.ConstructorError(

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-24079.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-24079.yaml
@@ -1,0 +1,20 @@
+name: ZenPacks.community.TestDEFAULSonDatasource
+
+device_classes:
+  /Device:
+    templates:
+      TESTTEMPLATE:
+        description: Testing that Duration threshold accepts integer values
+        datasources:
+          currentReading:
+            type: SNMP
+            datapoints:
+              currentReading: {}
+            oid: .1.3.6.1.4.1.232.6.2.6.8.1.4
+        thresholds:
+          DurationThreshold:
+            type: DurationThreshold
+            dsnames: [currentReading_currentReading]
+            violationPercentage: 10
+            timePeriod: 2 days
+


### PR DESCRIPTION
- fixes ZEN-24079
- added 'type_map' method that attempts to determine python data type
- falls back to default method 
- added zen-24079.yaml file to demonstrate issue
- updated ZPLTestHarness to deal with corner cases uncovered by this
issue