### PR TITLE
implement data type checking for extra_params when loading from YAML

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -5122,7 +5122,7 @@ if YAML_INSTALLED:
                     return map.get(k,'str')(node.value)
                 except:
                     pass
-    return loader.construct_shorthand(node)
+    return loader.construct_scalar(node)
 
     def construct_spec(cls, loader, node):
         """

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -5103,6 +5103,27 @@ if YAML_INSTALLED:
         # used to build this spec.
         return node
 
+    def type_map(loader, node):
+        '''map yaml node to python data type'''
+        map = {'int': int,
+               'float': float, 
+               'str': str,
+               'unicode': unicode,
+               'bool': bool,
+               'binary': str,
+               'set': set,
+               'seq': list,
+               'map': dict}
+        if 'null' in node.tag:
+            return None
+        for k in map.keys():
+            if k in node.tag:
+                try:
+                    return map.get(k,'str')(node.value)
+                except:
+                    pass
+    return loader.construct_shorthand(node)
+
     def construct_spec(cls, loader, node):
         """
         Generic constructor for deserializing specs from YAML.   Should be
@@ -5161,7 +5182,7 @@ if YAML_INSTALLED:
                     #
                     # Note that the values of these extra parameters need to be
                     # scalars, not nested maps or something like that.
-                    params[extra_params][yaml_key] = loader.construct_scalar(value_node)
+                    params[extra_params][yaml_key] = type_map(loader, value_node)
                     continue
                 else:
                     yaml_error(loader, yaml.constructor.ConstructorError(


### PR DESCRIPTION
- fixes ZEN-24079
- added 'type_map' method that attempts to determine python data type
- falls back to default method