### PR TITLE
avoid patching _relations on ZPL-derived subclasses (ZENPACK)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
@@ -230,7 +230,12 @@ class ZenPackSpec(Spec):
                     remote_relname = relationship.zenrelations_tuple[0]  # products_zenmodel_device_device
 
                     if relname not in (x[0] for x in remoteClassObj._relations):
-                        remoteClassObj._relations += ((relname, remoteType(localType, modname, remote_relname)),)
+                        rel = ((relname, remoteType(localType, modname, remote_relname)),)
+                        # do this differently if it's on a ZPL-based class
+                        if hasattr(remoteClassObj, '_v_local_relations'):
+                            remoteClassObj._v_local_relations += rel
+                        else:
+                            remoteClassObj._relations += rel
 
                     remote_module_id = remoteClassObj.__module__
                     if relname not in self.NEW_RELATIONS[remote_module_id]:

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-24018-1.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-24018-1.yaml
@@ -1,0 +1,16 @@
+##################################################################
+#
+#  This is designed to test whether or not a relation added to a 
+#  zenpacklib.Device subclass wipes out other relations added to 
+#  Products.ZenModel.Device (ZEN-24108)
+##################################################################
+
+name: ZenPacks.zenoss.ZenPackLib
+
+
+classes:
+  BasicDeviceComponent:
+    base: [zenpacklib.Component]
+
+class_relationships:
+- Products.ZenModel.Device.Device 1:MC BasicDeviceComponent

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-24018-2.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-24018-2.yaml
@@ -1,0 +1,19 @@
+##################################################################
+#
+#  This is designed to test whether or not a relation added to a 
+#  zenpacklib.Device subclass wipes out other relations added to 
+#  Products.ZenModel.Device (ZEN-24108)
+##################################################################
+
+
+name: ZenPacks.zenoss.ZPLDevice
+classes:
+  BaseDevice:
+    base: [zenpacklib.Device]
+
+  Device:
+    base: [BaseDevice]
+
+  ClusterDevice:
+    base: [Device]
+

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-24018-3.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-24018-3.yaml
@@ -1,0 +1,16 @@
+##################################################################
+#
+#  This is designed to test whether or not a relation added to a 
+#  zenpacklib.Device subclass wipes out other relations added to 
+#  Products.ZenModel.Device (ZEN-24108)
+##################################################################
+
+name: ZenPacks.zenoss.ZenPackLib
+
+classes:
+    SubClassComponent:
+        base: [zenpacklib.Component]
+
+class_relationships:
+  - ZenPacks.zenoss.ZPLDevice.Device.Device 1:MC SubClassComponent
+

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_zen_24018.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_zen_24018.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    This is designed to test whether or not a relation added to a 
+    zenpacklib.Device subclass wipes out other relations added to 
+    Products.ZenModel.Device (ZEN-24108)
+"""
+
+# stdlib Imports
+import os
+import unittest
+import logging
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger('zen.zenpacklib.tests')
+
+from .ZPLTestHarness import ZPLTestHarness
+
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+
+class TestZen24018(unittest.TestCase):
+
+    """Specs test suite."""
+    zps = []
+
+    def setUp(self):
+        fdir = '%s/data/yaml' % os.path.dirname(__file__)
+        self.base_device_file = '%s/%s' % (fdir, 'zen-24018-1.yaml')
+        self.device_subclass_file = '%s/%s' % (fdir, 'zen-24018-2.yaml')
+        self.subclass_relation_file = '%s/%s' % (fdir, 'zen-24018-3.yaml')
+
+
+    def test_inherited_relations(self):
+        device_subclass_zp = ZPLTestHarness(self.device_subclass_file)
+        base_device_zp = ZPLTestHarness(self.base_device_file)
+        subclass_relation_zp = ZPLTestHarness(self.subclass_relation_file)
+
+        from Products.ZenModel.Device import Device as ZenDevice
+        from ZenPacks.zenoss.ZPLDevice.BaseDevice import BaseDevice
+        from ZenPacks.zenoss.ZPLDevice.Device import Device
+        from ZenPacks.zenoss.ZPLDevice.ClusterDevice import ClusterDevice
+
+        # all ZenModel.Device subclasses should have this relation
+        for x in [ZenDevice, BaseDevice, Device, ClusterDevice]:
+            # should be True
+            self.assertTrue(self.has_relation(ZenDevice, 'basicDeviceComponents'),
+                            '%s is missing relation: basicDeviceComponents' % x.__name__)
+
+        # these should have subClassComponents
+        for x in [Device, ClusterDevice]:
+            self.assertTrue(self.has_relation(ZenDevice, 'subClassComponents'),
+                            '%s is missing relation: subClassComponents' % x.__name__)
+
+        # these should not have subClassComponents
+        for x in [ZenDevice, BaseDevice]:
+            self.assertTrue(self.has_relation(ZenDevice, 'subClassComponents'),
+                            '%s is missing relation: subClassComponents' % x.__name__)
+
+    def has_relation(self, cls, relname):
+        if relname in dict(cls._relations).keys():
+            return True
+        return False
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestZen24018))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()


### PR DESCRIPTION
- Fixes ZEN-24018
- detect and use '_v_local_relations' if present on imported class
- prevents overwriting _relations attribute, which precludes further
ZPL-based modification
- does not prevent direct _relations override by non-ZPL ZenPacks
(__init__.py method), so these will need to be modified to target
_v_local_relations when applying relations to ZPL-derived subclasses
- added test case