### PR TITLE
avoid patching _relations on ZPL-derived subclasses

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -1662,7 +1662,12 @@ class ZenPackSpec(Spec):
                     remote_relname = relationship.zenrelations_tuple[0]  # products_zenmodel_device_device
 
                     if relname not in (x[0] for x in remoteClassObj._relations):
-                        remoteClassObj._relations += ((relname, remoteType(localType, modname, remote_relname)),)
+                        rel = ((relname, remoteType(localType, modname, remote_relname)),)
+                        # do this differently if it's on a ZPL-based class
+                        if hasattr(remoteClassObj, '_v_local_relations'):
+                            remoteClassObj._v_local_relations += rel
+                        else:
+                            remoteClassObj._relations += rel
 
                     remote_module_id = remoteClassObj.__module__
                     if relname not in self.NEW_RELATIONS[remote_module_id]:


### PR DESCRIPTION
- Fixes ZEN-24018
- detect and use '_v_local_relations' if present on imported class
- prevents overwriting _relations attribute, which precludes further
ZPL-based modification
- does not prevent direct _relations override by non-ZPL ZenPacks
(__init__.py method), so these will need to be modified to target
_v_local_relations when applying relations to ZPL-derived subclasses