### PR TITLE
Prevent attempts to process relationships not in class_relationships

### DIFF
--- a/tests/test_zen_21927.py
+++ b/tests/test_zen_21927.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""undefined relations unit tests
+
+This module tests zenpacklib handling of class 'relations' attributes for undefined class_relations.
+
+"""
+# stdlib Imports
+import os
+import site
+import tempfile
+import traceback
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+# zenpacklib Imports
+site.addsitedir(os.path.join(os.path.dirname(__file__), '..'))
+import zenpacklib
+
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+
+YAML = """
+name: ZenPacks.zenoss.SomeZenPack
+
+class_relationships:
+- BaseDevice 1:MC BaseComponent
+
+
+classes:
+  BaseDevice:
+    base: [zenpacklib.Device]
+    relationships:
+      baseComponents: {}
+      # this doesn't exist
+      auxComponents: {}
+      # These exist but aren't defined in this schema
+      systems: {}
+      deviceClass: {}
+
+  BaseComponent:
+    # Component Base Type
+    base: [zenpacklib.Component]
+    relationships:
+      baseDevice: {}
+      # this doesn't exist
+      auxComponents: {}
+
+  AuxComponent:
+    # Component Base Type
+    base: [zenpacklib.Component]
+    relationships:
+      # this exists but isn't defined in this schema
+dependents: {}
+"""
+
+
+class TestZen21927(BaseTestCase):
+    """Test removal of undefined relations"""
+
+    def test_undefined_relations(self):
+        ''''''
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(YAML.strip())
+            f.flush()
+            try:
+                cfg = zenpacklib.load_yaml(f.name)
+            except:
+                msg = traceback.format_exc(limit=0)
+                self.fail(msg)
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestZen21927))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()
+

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -1661,10 +1661,12 @@ class ZenPackSpec(Spec):
                                         class_.relationships[target_relname].schema = target_schema
                                     continue
 
+        for class_ in self.classes.values():
             # Plumb _relations
             for relname, relationship in class_.relationships.iteritems():
                 if not relationship.schema:
-                    LOG.error("Class '%s': no relationship schema has been defined for relationship '%s'" % (class_.name, relname))
+                    LOG.error("Removing invalid display config for relationship %s from  %s.%s" % (relname, self.name, class_.name))
+                    class_.relationships.pop(relname)
                     continue
 
                 if relationship.schema.remoteClass in self.imported_classes.keys():


### PR DESCRIPTION
- Fixes ZEN-21927
- modify ZenPackSpec init to remove relations without a known schema
(not specified in class_relationships)
- added test case for fix