### PR TITLE
We should only look for callable attributes and some js words

### DIFF
--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -36,12 +36,18 @@ classes:
                 label: UUID
             yield:
                 label: Yield
+            name:
+                label: Name
+            memory:
+                label: Memory
     lambda:
         base: [zenpacklib.Component]
         label: Lambda
         properties:
             prop1:
                 label: yield
+            uuid:
+                label: UUID
 
 zProperties:
     zCommandUsername:
@@ -64,6 +70,7 @@ device_classes:
                             rrdtype: GAUGE
                             rrdmin: 0
                             rrdmax: 100
+                            breadCrumbs: 0
 
 """
 NO_RESERVED_YAML = """name: ZenPacks.zenoss.Example
@@ -113,11 +120,13 @@ class TestKeywords(BaseTestCommand):
             f.write(RESERVED_YAML.strip())
             f.flush()
             out = self._smoke_command('lint', f.name).strip().split('\n')
-            self.assertEquals(4, len(out))
+            self.assertEquals(6, len(out))
             self.assertIn("Found reserved keyword 'uuid'", out[0])
             self.assertIn("Found reserved keyword 'yield'", out[1])
-            self.assertIn("Found reserved keyword 'lambda'", out[2])
+            self.assertIn("Found reserved keyword 'name'", out[2])
             self.assertIn("Found reserved keyword 'lambda'", out[3])
+            self.assertIn("Found reserved keyword 'uuid'", out[4])
+            self.assertIn("Found reserved keyword 'lambda'", out[5])
 
             f.close()
 

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -171,14 +171,20 @@ GSM = getGlobalSiteManager()
 def getZenossKeywords(klasses):
     kwset = set()
     for klass in klasses:
-        kwset = kwset.union(set(dir(klass)))
+        for k in klass.__dict__.keys():
+            if callable(getattr(klass, k)):
+                kwset = kwset.union([k])
+        for attribute in dir(klass):
+            if callable(getattr(klass, attribute)):
+                kwset = kwset.union([attribute])
     return kwset
 
 ZENOSS_KEYWORDS = getZenossKeywords([BaseDevice,
-                                     BaseDeviceComponent,
-                                     BaseDeviceInfo,
-                                     BaseComponentInfo])
+                                    BaseDeviceInfo,
+                                    BaseDeviceComponent,
+                                    BaseComponentInfo])
 
+JS_WORDS = set(['uuid', 'uid', 'meta_type', 'monitor', 'severity', 'monitored', 'locking'])
 
 # Public Classes ############################################################
 
@@ -4942,7 +4948,7 @@ if YAML_INSTALLED:
                 None, None,
                 "Found reserved keyword '{}' while processing {}".format(key, cls.__name__),
                 start_mark))
-        elif key in ZENOSS_KEYWORDS:
+        elif key in ZENOSS_KEYWORDS.union(JS_WORDS):
             # should be ok to use a zenoss word to define these
             # some items, like sysUpTime are pretty common datapoints
             if cls not in [RRDDatasourceSpec,


### PR DESCRIPTION
Fixes ZEN-19460

Changed so that we look at only callable attributes and included
some js words like uuid