### PR TITLE
Multiple YAML file support, support for optimized YAML formatting

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/__init__.py
+++ b/ZenPacks/zenoss/ZenPackLib/__init__.py
@@ -13,9 +13,11 @@
 # through monkey-patching.
 import os
 import Globals
+import sys
 
 from Products.ZenModel.ZenPack import ZenPack as ZenPackBase
 from Products.ZenUtils.Utils import unused, zenPath
+from .lib.utils import yaml_installed
 
 unused(Globals)
 #
@@ -24,9 +26,11 @@ class ZenPack(ZenPackBase):
     '''ZenPack'''
 
     def install(self, dmd):
-        ZenPackBase.install(self, dmd)
-        self.create_symlink()
-
+        if yaml_installed():
+            ZenPackBase.install(self, dmd)
+            self.create_symlink()
+        else:
+            sys.exit(1)
 
     def remove(self, dmd, leaveObjects=False):
         if not leaveObjects:

--- a/ZenPacks/zenoss/ZenPackLib/lib/functions.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/functions.py
@@ -5,86 +5,59 @@ import imp
 import sys
 import operator
 import re
-import yaml
-import time
-import keyword
-import logging
-from collections import OrderedDict
 from Products.AdvancedQuery.AdvancedQuery import _BaseQuery as BaseQuery
 
-from .utils import yaml_installed
-from .helpers.Loader import Loader
-from .helpers.ZenPackLibLog import ZenPackLibLog
+from Products.ZenModel.Device import Device as BaseDevice
+from Products.Zuul.infos.device import DeviceInfo as BaseDeviceInfo
+from Products.ZenModel.DeviceComponent import DeviceComponent as BaseDeviceComponent
+from Products.Zuul.infos.component import ComponentInfo as BaseComponentInfo
+from .helpers.ZenPackLibLog import LOG
 
 
-ZPLOG = ZenPackLibLog()
-LOG = ZPLOG.defaultlog
+# Private Functions ######################################################### 
 
 
-# Default log settings
-QUIET=True
-LEVEL=0
+def getZenossKeywords(klasses):
+    kwset = set()
+    for klass in klasses:
+        for k in klass.__dict__.keys():
+            if callable(getattr(klass, k)):
+                kwset = kwset.union([k])
+        for attribute in dir(klass):
+            if callable(getattr(klass, attribute)):
+                kwset = kwset.union([attribute])
+    return kwset
+
+ZENOSS_KEYWORDS = getZenossKeywords([BaseDevice,
+                                     BaseDeviceInfo,
+                                     BaseDeviceComponent,
+                                     BaseComponentInfo])
+
+JS_WORDS = set(['uuid', 'uid', 'meta_type', 'monitor', 'severity', 'monitored', 'locking'])
 
 
-def load_yaml(yaml_filename=None, verbose=False, level=0):
-    """Load YAML from yaml_filename.
-    Loads from zenpack.yaml in the current directory if
-    yaml_filename isn't specified.
-    """
-
-    # these control logging on a per-ZenPack basis
-    global QUIET, LEVEL
-    QUIET = not verbose
-    LEVEL = level
-
-    start = time.time()
-    CFG = None
-    if yaml_installed():
-        if yaml_filename is None:
-            yaml_filename = os.path.join(
-                os.path.dirname(__file__), 'zenpack.yaml')
-
-        try:
-            LOG.info("Loading YAML from %s" % yaml_filename)
-            CFG = yaml.load(file(yaml_filename, 'r'), Loader=Loader)
-        except Exception as e:
-            if not [x for x in LOG.handlers if not isinstance(x, logging.NullHandler)]:
-                # Logging has not ben initialized yet- LOG.error may not be
-                # seen.
-                logging.basicConfig()
-            LOG.error(e)
-    else:
-        zenpack_name = None
-
-        # Guess ZenPack name from the path.
-        dirname = __file__
-
-        while dirname != '/':
-            dirname = os.path.dirname(dirname)
-            basename = os.path.basename(dirname)
-            if basename.startswith('ZenPacks.'):
-                zenpack_name = basename
-                break
-
-        LOG.error(
-            '%s requires PyYAML. Run "easy_install PyYAML".',
-            zenpack_name or 'ZenPack')
-
-        from spec.ZenPackSpec import ZenPackSpec
-        # Create a simple ZenPackSpec that should be harmless.
-        CFG = ZenPackSpec(name=zenpack_name or 'NoYAML')
-
-    if CFG:
-        CFG.create()
-    else:
-        LOG.error("Unable to load %s", yaml_filename)
-
-    end = time.time() - start
-    LOG.info("Loaded %s in %0.2f s" % (yaml_filename, end))
-    return CFG
+def find_keyword_cls(keyword):
+    names = []
+    for k in [BaseDevice, BaseDeviceComponent, BaseDeviceInfo, BaseComponentInfo]:
+        if keyword in dir(k):
+            names.append(k.__name__)
+    return names
 
 
-# Private Functions #########################################################
+def relname_from_classname(classname, plural=False):
+    """Return relationship name given classname and plural flag."""
+
+    if '.' in classname:
+        classname = classname.replace('.', '_').lower()
+
+    relname = list(classname)
+    for i, c in enumerate(classname):
+        if relname[i].isupper():
+            relname[i] = relname[i].lower()
+        else:
+            break
+
+    return ''.join((''.join(relname), 's' if plural else ''))
 
 
 def get_zenpack_path(zenpack_name):
@@ -131,7 +104,7 @@ def catalog_search(scope, name, *args, **kwargs):
 
     catalog = getattr(scope, '{}Search'.format(name), None)
     if not catalog:
-        LOG.debug("Catalog %sSearch not found at %s.  It should be created when the first included component is indexed" % (name, scope))
+        LOG.debug("Catalog {}Search not found at {}.  It should be created when the first included component is indexed".format(name, scope))
         return []
 
     if args:
@@ -259,7 +232,7 @@ def relationships_from_yuml(yuml):
 
         match = match_line(line)
         if not match:
-            raise ValueError("parse error in relationships_from_yuml at %s" % line)
+            raise ValueError("parse error in relationships_from_yuml at {}".format(line))
 
         left_class = match.group('left_classname')
         right_class = match.group('right_classname')
@@ -316,697 +289,6 @@ def relationships_from_yuml(yuml):
 
 # Public Functions #########################################################
 
-from Products.ZenModel.Device import Device as BaseDevice
-from Products.Zuul.infos.device import DeviceInfo as BaseDeviceInfo
-from Products.ZenModel.DeviceComponent import DeviceComponent as BaseDeviceComponent
-from Products.Zuul.infos.component import ComponentInfo as BaseComponentInfo
-
-def getZenossKeywords(klasses):
-    kwset = set()
-    for klass in klasses:
-        for k in klass.__dict__.keys():
-            if callable(getattr(klass, k)):
-                kwset = kwset.union([k])
-        for attribute in dir(klass):
-            if callable(getattr(klass, attribute)):
-                kwset = kwset.union([attribute])
-    return kwset
-
-ZENOSS_KEYWORDS = getZenossKeywords([BaseDevice,
-                                    BaseDeviceInfo,
-                                    BaseDeviceComponent,
-                                    BaseComponentInfo])
-
-JS_WORDS = set(['uuid', 'uid', 'meta_type', 'monitor', 'severity', 'monitored', 'locking'])
-
-
-def find_keyword_cls(keyword):
-    names = []
-    for k in [BaseDevice, BaseDeviceComponent, BaseDeviceInfo, BaseComponentInfo]:
-        if keyword in dir(k):
-            names.append(k.__name__)
-    return names
-
-
-def relschemaspec_to_str(spec):
-    # Omit relation names that are their defaults.
-    left_optrelname = "" if spec.left_relname == spec.default_left_relname else "(%s)" % spec.left_relname
-    right_optrelname = "" if spec.right_relname == spec.default_right_relname else "(%s)" % spec.right_relname
-
-    return "%s%s %s:%s %s%s" % (
-        spec.left_class,
-        left_optrelname,
-        spec.left_cardinality,
-        spec.right_cardinality,
-        right_optrelname,
-        spec.right_class
-    )
-
-
-def str_to_relschemaspec(schemastr):
-    schema_pattern = re.compile(
-        r'^\s*(?P<left>\S+)'
-        r'\s+(?P<cardinality>1:1|1:M|1:MC|M:M)'
-        r'\s+(?P<right>\S+)\s*$',
-    )
-
-    class_rel_pattern = re.compile(
-        r'(\((?P<pre_relname>[^\)\s]+)\))?'
-        r'(?P<class>[^\(\s]+)'
-        r'(\((?P<post_relname>[^\)\s]+)\))?'
-    )
-
-    m = schema_pattern.search(schemastr)
-    if not m:
-        raise ValueError("RelationshipSchemaSpec '{}' is not valid".format(schemastr))
-
-    ml = class_rel_pattern.search(m.group('left'))
-    if not ml:
-        raise ValueError("RelationshipSchemaSpec '{}' left side is not valid".format(m.group('left')))
-
-    mr = class_rel_pattern.search(m.group('right'))
-    if not mr:
-        raise ValueError("RelationshipSchemaSpec '{}' right side is not valid".format(m.group('right')))
-
-    reltypes = {
-        '1:1': ('ToOne', 'ToOne'),
-        '1:M': ('ToMany', 'ToOne'),
-        '1:MC': ('ToManyCont', 'ToOne'),
-        'M:M': ('ToMany', 'ToMany')
-    }
-
-    left_class = ml.group('class')
-    right_class = mr.group('class')
-    left_type = reltypes.get(m.group('cardinality'))[0]
-    right_type = reltypes.get(m.group('cardinality'))[1]
-
-    left_relname = ml.group('pre_relname') or ml.group('post_relname')
-    if left_relname is None:
-        left_relname = relname_from_classname(right_class, plural=left_type != 'ToOne')
-
-    right_relname = mr.group('pre_relname') or mr.group('post_relname')
-    if right_relname is None:
-        right_relname = relname_from_classname(left_class, plural=right_type != 'ToOne')
-
-    return dict(
-        left_class=left_class,
-        left_relname=left_relname,
-        left_type=left_type,
-        right_type=right_type,
-        right_class=right_class,
-        right_relname=right_relname
-    )
-
-
-def str_to_class(classstr):
-    if classstr == 'object':
-        return object
-
-    if "." not in classstr:
-        # TODO: Support non qualfied class names, searching zenpack, zenpacklib,
-        # and ZenModel namespaces
-
-        # An unqualified class name is assumed to be referring to one in
-        # the classes defined in this ZenPackSpec.   We can't validate this,
-        # or return a class object for it, if this is the case.  So we
-        # return no class object, and the caller will assume that it
-        # it refers to a class being defined.
-        return None
-
-    modname, classname = classstr.rsplit(".", 1)
-    # ensure that 'zenpacklib' refers to *this* zenpacklib, if more than
-    # one is loaded in the system.
-    if modname == 'zenpacklib':
-        modpath = '.'.join(__name__.split('.')[:-1])
-        modname = '%s.base.%s' % (modpath, classname)
-    try:
-        class_ = getattr(importlib.import_module(modname), classname)
-    except Exception, e:
-        raise ValueError("Class '{}' is not valid: {}".format(classstr, e))
-
-    return class_
-
-
-def severity_to_str(value):
-    '''
-    Return string representation for severity given a numeric value.
-    '''
-    severity = {
-        5: 'crit',
-        4: 'err',
-        3: 'warn',
-        2: 'info',
-        1: 'debug',
-        0: 'clear'
-        }.get(value, None)
-
-    if severity is None:
-        raise ValueError("'{}' is not a valid value for severity.".format(value))
-
-    return severity
-
-
-def str_to_severity(value):
-    '''
-    Return numeric severity given a string representation of severity.
-    '''
-    try:
-        severity = int(value)
-    except (TypeError, ValueError):
-        severity = {
-            'crit': 5, 'critical': 5,
-            'err': 4, 'error': 4,
-            'warn': 3, 'warning': 3,
-            'info': 2, 'information': 2, 'informational': 2,
-            'debug': 1, 'debugging': 1,
-            'clear': 0,
-            }.get(value.lower())
-
-    if severity is None:
-        raise ValueError("'{}' is not a valid value for severity.".format(value))
-
-    return severity
-
-
-def format_message(e):
-    message = []
-
-    mark = e.context_mark or e.problem_mark
-    if mark:
-        name = mark.name.split('/')[-1]
-        position = "({} line {}:{})".format(name, mark.line + 1, mark.column + 1)
-    else:
-        position = "[unknown]"
-    if e.context is not None:
-        message.append(e.context)
-
-    if e.problem is not None:
-        message.append(e.problem)
-
-    if e.note is not None:
-        message.append("(note: " + e.note + ")")
-
-    return "{} {}".format(position, ' '.join(message))
-
-
-def yaml_warning(loader, e):
-    """
-        Given a MarkedYAMLError exception, log
-        the error
-    """
-    LOG.warn(format_message(e))
-
-
-def yaml_error(loader, e, exc_info=None):
-    """
-        Given a MarkedYAMLError exception, either log or raise
-        the error, depending on the 'fatal' argument.
-    """
-    fatal = not getattr(loader, 'warnings', False)
-    setattr(loader, 'yaml_errored', True)
-
-    if exc_info:
-        # When we're given the original exception (which was wrapped in
-        # a MarkedYAMLError), we can provide more context for debugging.
-
-        from traceback import format_exc
-        e.note = "\nOriginal exception:\n" + format_exc(exc_info)
-
-    if fatal:
-        raise e
-
-    LOG.error(format_message(e))
-
-
-def verify_key(loader, cls, params, key, start_mark):
-    # always ok to use a param name (description, name, etc.)
-    if key in params.keys():
-        return True
-
-    # never use a python reserved word
-    if key in keyword.kwlist:
-        yaml_error(loader, yaml.constructor.ConstructorError(
-            None, None,
-            "Found reserved python keyword '{}' while processing {}".format(key, cls.__name__),
-            start_mark))
-    elif key in ZENOSS_KEYWORDS.union(JS_WORDS):
-        # should be ok to use a zenoss word to define these
-        # some items, like sysUpTime are pretty common datapoints
-        if cls.__name__ not in ['RRDDatasourceSpec',
-                                'RRDDatapointSpec',
-                                'RRDTemplateSpec',
-                                'GraphDefinitionSpec',
-                                'GraphPointSpec']:
-            klasses = ', '.join(find_keyword_cls(key))
-            yaml_warning(loader, yaml.constructor.ConstructorError(
-                None, None,
-                "Found reserved Zenoss keyword '{}' from {}".format(key, klasses),
-                start_mark))
-
-    return False
-
-
-def construct_specsparameters(loader, node, spectype):
-    from spec.Spec import Spec
-
-    spec_class = {x.__name__: x for x in Spec.__subclasses__()}.get(spectype, None)
-
-    if not spec_class:
-        yaml_error(loader, yaml.constructor.ConstructorError(
-            None, None,
-            "Unrecognized Spec class %s" % spectype,
-            node.start_mark))
-        return
-
-    if not isinstance(node, yaml.MappingNode):
-        yaml_error(loader, yaml.constructor.ConstructorError(
-            None, None,
-            "expected a mapping node, but found %s" % node.id,
-            node.start_mark))
-        return
-
-    param_defs = spec_class.init_params()
-    specs = OrderedDict()
-    for spec_key_node, spec_value_node in node.value:
-        try:
-            spec_key = str(loader.construct_scalar(spec_key_node))
-            verify_key(loader, spec_class, param_defs, spec_key, spec_key_node.start_mark)
-
-        except yaml.MarkedYAMLError, e:
-            yaml_error(loader, e)
-
-        specs[spec_key] = construct_spec(spec_class, loader, spec_value_node)
-
-    return specs
-
-
-def represent_relschemaspec(dumper, data):
-    """
-    Generic representer for serializing relation specs to YAML.
-    """
-    return dumper.represent_str(relschemaspec_to_str(data))
-
-
-def represent_spec(dumper, obj, yaml_tag=u'tag:yaml.org,2002:map', defaults=None):
-    """
-    Generic representer for serializing specs to YAML.  Rather than using
-    the default PyYAML representer for python objects, we very carefully
-    build up the YAML according to the parameter definitions in the __init__
-    of each spec class.  This same format is used by construct_spec (the YAML
-    constructor) to ensure that the spec objects are built consistently,
-    whether it is done via YAML or the API.
-    """
-    from spec.RRDDatapointSpec import RRDDatapointSpec
-    if isinstance(obj, RRDDatapointSpec) and obj.shorthand:
-        # Special case- we allow for a shorthand in specifying datapoints
-        # as specs as strings rather than explicitly as a map.
-        return dumper.represent_str(str(obj.shorthand))
-
-    mapping = OrderedDict()
-    cls = obj.__class__
-    param_defs = cls.init_params()
-    for param in param_defs:
-        type_ = param_defs[param]['type']
-
-        try:
-            value = getattr(obj, param)
-        except AttributeError:
-            raise yaml.representer.RepresenterError(
-                "Unable to serialize %s object: %s, a supported parameter, is not accessible as a property." %
-                (cls.__name__, param))
-            continue
-
-        # Figure out what the default value is.  First, consider the default
-        # value for this parameter (globally):
-        default_value = param_defs[param].get('default', None)
-
-        # Now, we need to handle 'DEFAULTS'.  If we're in a situation
-        # where that is supported, and we're outputting a spec that
-        # would be affected by it (not DEFAULTS itself, in other words),
-        # then we look at the default value for this parameter, in case
-        # it has changed the global default for this parameter.
-        if hasattr(obj, 'name') and obj.name != 'DEFAULTS' and defaults is not None:
-            default_value = getattr(defaults, param, default_value)
-
-        if value == default_value:
-            # If the value is a default value, we can omit it from the export.
-            continue
-
-        # If the value is null and the type is a list or dictionary, we can
-        # assume it was some optional nested data and omit it.
-        if value is None and (
-           type_.startswith('dict') or
-           type_.startswith('list') or
-           type_.startswith('SpecsParameter')):
-            continue
-
-        if type_ == 'ZPropertyDefaultValue':
-            # For zproperties, the actual data type of a default value
-            # depends on the defined type of the zProperty.
-            try:
-                type_ = {
-                    'boolean': "bool",
-                    'int': "int",
-                    'float': "float",
-                    'string': "str",
-                    'password': "str",
-                    'lines': "list(str)"
-                }.get(obj.type_, 'str')
-            except KeyError:
-                type_ = "str"
-
-        yaml_param = dumper.represent_str(param_defs[param]['yaml_param'])
-        try:
-            if type_ == "bool":
-                mapping[yaml_param] = dumper.represent_bool(value)
-            elif type_.startswith("dict"):
-                mapping[yaml_param] = dumper.represent_dict(value)
-            elif type_ == "float":
-                mapping[yaml_param] = dumper.represent_float(value)
-            elif type_ == "int":
-                mapping[yaml_param] = dumper.represent_int(value)
-            elif type_ == "list(class)":
-                # The "class" in this context is either a class reference or
-                # a class name (string) that refers to a class defined in
-                # this ZenPackSpec.
-                classes = [isinstance(x, type) and class_to_str(x) or x for x in value]
-                mapping[yaml_param] = dumper.represent_list(classes)
-            elif type_.startswith("list(ExtraPath)"):
-                # Represent this as a list of lists of quoted strings (each on one line).
-                paths = []
-                for path in list(value):
-                    # Force the regular expressions to be quoted, so we don't have any issues with that.
-                    pathnodes = [dumper.represent_scalar(u'tag:yaml.org,2002:str', x, style="'") for x in path]
-                    paths.append(yaml.SequenceNode(u'tag:yaml.org,2002:seq', pathnodes, flow_style=True))
-                mapping[yaml_param] = yaml.SequenceNode(u'tag:yaml.org,2002:seq', paths, flow_style=False)
-            elif type_.startswith("list"):
-                mapping[yaml_param] = dumper.represent_list(value)
-            elif type_ == "str":
-                mapping[yaml_param] = dumper.represent_str(value)
-            elif type_ == 'RelationshipSchemaSpec':
-                mapping[yaml_param] = dumper.represent_str(relschemaspec_to_str(value))
-            elif type_ == 'Severity':
-                mapping[yaml_param] = dumper.represent_str(severity_to_str(value))
-            elif type_ == 'ExtraParams':
-                # ExtraParams is a special case, where any 'extra'
-                # parameters not otherwise defined in the init_params
-                # definition are tacked into a dictionary with no specific
-                # schema validation.  This is meant to be used in situations
-                # where it is impossible to know what parameters will be
-                # needed ahead of time, such as with a datasource
-                # that has been subclassed and had new properties added.
-                #
-                # Note: the extra parameters are required to have scalar
-                # values only.
-                for extra_param in value:
-                    # add any values from an extraparams dict onto the spec's parameter list directly.
-                    yaml_extra_param = dumper.represent_str(extra_param)
-
-                    mapping[yaml_extra_param] = dumper.represent_data(value[extra_param])
-            else:
-                m = re.match('^SpecsParameter\((.*)\)$', type_)
-                if m:
-                    spectype = m.group(1)
-                    specmapping = OrderedDict()
-                    keys = sorted(value)
-                    defaults = None
-                    if 'DEFAULTS' in keys:
-                        keys.remove('DEFAULTS')
-                        keys.insert(0, 'DEFAULTS')
-                        defaults = value['DEFAULTS']
-                    for key in keys:
-                        spec = value[key]
-                        if type(spec).__name__ != spectype:
-                            raise yaml.representer.RepresenterError(
-                                "Unable to serialize %s object (%s):  Expected an object of type %s" %
-                                (type(spec).__name__, key, spectype))
-                        else:
-                            specmapping[dumper.represent_str(key)] = represent_spec(dumper, spec, defaults=defaults)
-
-                    specmapping_value = []
-                    node = yaml.MappingNode(yaml_tag, specmapping_value)
-                    specmapping_value.extend(specmapping.items())
-                    mapping[yaml_param] = node
-                else:
-                    raise yaml.representer.RepresenterError(
-                        "Unable to serialize %s object: %s, a supported parameter, is of an unrecognized type (%s)." %
-                        (cls.__name__, param, type_))
-        except yaml.representer.RepresenterError:
-            raise
-        except Exception, e:
-            raise yaml.representer.RepresenterError(
-                "Unable to serialize %s object (param %s, type %s, value %s): %s" %
-                (cls.__name__, param, type_, value, e))
-
-        if param in param_defs and param_defs[param]['yaml_block_style']:
-            mapping[yaml_param].flow_style = False
-
-    mapping_value = []
-    node = yaml.MappingNode(yaml_tag, mapping_value)
-    mapping_value.extend(mapping.items())
-
-    # Return a node describing the mapping (dictionary) of the params
-    # used to build this spec.
-    return node
-
-
-def construct_spec(cls, loader, node):
-    """
-    Generic constructor for deserializing specs from YAML.   Should be
-    the opposite of represent_spec, and works in the same manner (with its
-    parsing and validation directed by the init_params of each spec class)
-    """
-    from spec.RRDDatapointSpec import RRDDatapointSpec
-    if issubclass(cls, RRDDatapointSpec) and isinstance(node, yaml.ScalarNode):
-        # Special case- we allow for a shorthand in specifying datapoint specs.
-        return dict(shorthand=loader.construct_scalar(node))
-
-    param_defs = cls.init_params()
-    params = {}
-    if not isinstance(node, yaml.MappingNode):
-        yaml_error(loader, yaml.constructor.ConstructorError(
-            None, None,
-            "expected a mapping node, but found %s" % node.id,
-            node.start_mark))
-
-    params['_source_location'] = "%s: %s-%s" % (
-        os.path.basename(node.start_mark.name),
-        node.start_mark.line+1,
-        node.end_mark.line+1)
-
-    # TODO: When deserializing, we should check if required properties are present.
-
-    param_name_map = {}
-    for param in param_defs:
-        param_name_map[param_defs[param]['yaml_param']] = param
-
-    extra_params = None
-    for key in param_defs:
-        if param_defs[key]['type'] == 'ExtraParams':
-            if extra_params:
-                yaml_error(loader, yaml.constructor.ConstructorError(
-                    None, None,
-                    "Only one ExtraParams parameter may be specified.",
-                    node.start_mark))
-            extra_params = key
-            params[extra_params] = {}
-
-    for key_node, value_node in node.value:
-        yaml_key = str(loader.construct_scalar(key_node))
-        verify_key(loader, cls, param_defs, yaml_key, key_node.start_mark)
-
-        if yaml_key not in param_name_map:
-            if extra_params:
-                # If an 'extra_params' parameter is defined for this spec,
-                # we take all unrecognized paramters and stuff them into
-                # a single parameter, which is a dictonary of "extra" parameters.
-                #
-                # Note that the values of these extra parameters need to be
-                # scalars, not nested maps or something like that.
-                params[extra_params][yaml_key] = loader.construct_scalar(value_node)
-                continue
-            else:
-                yaml_error(loader, yaml.constructor.ConstructorError(
-                    None, None,
-                    "Unrecognized parameter '%s' found while processing %s" % (yaml_key, cls.__name__),
-                    key_node.start_mark))
-                continue
-
-        key = param_name_map[yaml_key]
-        expected_type = param_defs[key]['type']
-
-        if expected_type == 'ZPropertyDefaultValue':
-            # For zproperties, the actual data type of a default value
-            # depends on the defined type of the zProperty.
-
-            try:
-                zPropType = [x[1].value for x in node.value if x[0].value == 'type'][0]
-            except Exception:
-                # type was not specified, so we assume the default (string)
-                zPropType = 'string'
-
-            try:
-                expected_type = {
-                    'boolean': "bool",
-                    'int': "int",
-                    'float': "float",
-                    'string': "str",
-                    'password': "str",
-                    'lines': "list(str)"
-                }.get(zPropType, 'str')
-            except KeyError:
-                yaml_error(loader, yaml.constructor.ConstructorError(
-                    None, None,
-                    "Invalid zProperty type_ '%s' for property %s found while processing %s" % (zPropType, key, cls.__name__),
-                    key_node.start_mark))
-                continue
-
-        try:
-            if expected_type == "bool":
-                params[key] = loader.construct_yaml_bool(value_node)
-            elif expected_type.startswith("dict(SpecsParameter("):
-                m = re.match('^dict\(SpecsParameter\((.*)\)\)$', expected_type)
-                if m:
-                    spectype = m.group(1)
-
-                    if not isinstance(node, yaml.MappingNode):
-                        yaml_error(loader, yaml.constructor.ConstructorError(
-                            None, None,
-                            "expected a mapping node, but found %s" % node.id,
-                            node.start_mark))
-                        continue
-                    specs = OrderedDict()
-                    for spec_key_node, spec_value_node in value_node.value:
-                        spec_key = str(loader.construct_scalar(spec_key_node))
-
-                        specs[spec_key] = construct_specsparameters(loader, spec_value_node, spectype)
-                    params[key] = specs
-                else:
-                    raise Exception("Unable to determine specs parameter type in '%s'" % expected_type)
-            elif expected_type.startswith("dict"):
-                params[key] = loader.construct_mapping(value_node)
-            elif expected_type == "float":
-                params[key] = float(loader.construct_scalar(value_node))
-            elif expected_type == "int":
-                params[key] = int(loader.construct_scalar(value_node))
-            elif expected_type == "list(class)":
-                classnames = loader.construct_sequence(value_node)
-                classes = []
-                for c in classnames:
-                    class_ = str_to_class(c)
-                    if class_ is None:
-                        # local reference to a class being defined in
-                        # this zenpack.  (ideally we should verify that
-                        # the name is valid, but this is not possible
-                        # in a one-pass parsing of the yaml).
-                        classes.append(c)
-                    else:
-                        classes.append(class_)
-                # ZPL defines "class" as either a string representing a
-                # class in this definition, or a class object representing
-                # an external class.
-                params[key] = classes
-            elif expected_type == 'list(ExtraPath)':
-                if not isinstance(value_node, yaml.SequenceNode):
-                    raise yaml.constructor.ConstructorError(
-                        None, None,
-                        "expected a sequence node, but found %s" % value_node.id,
-                        value_node.start_mark)
-                extra_paths = []
-                for path_node in value_node.value:
-                    extra_paths.append(loader.construct_sequence(path_node))
-                params[key] = extra_paths
-            elif expected_type == "list(RelationshipSchemaSpec)":
-                schemaspecs = []
-                for s in loader.construct_sequence(value_node):
-                    schemaspecs.append(str_to_relschemaspec(s))
-                params[key] = schemaspecs
-            elif expected_type.startswith("list"):
-                params[key] = loader.construct_sequence(value_node)
-            elif expected_type == "str":
-                params[key] = str(loader.construct_scalar(value_node))
-            elif expected_type == 'RelationshipSchemaSpec':
-                schemastr = str(loader.construct_scalar(value_node))
-                params[key] = str_to_relschemaspec(schemastr)
-            elif expected_type == 'Severity':
-                severitystr = str(loader.construct_scalar(value_node))
-                params[key] = str_to_severity(severitystr)
-            else:
-                m = re.match('^SpecsParameter\((.*)\)$', expected_type)
-                if m:
-                    spectype = m.group(1)
-                    params[key] = construct_specsparameters(loader, value_node, spectype)
-                else:
-                    raise Exception("Unhandled type '%s'" % expected_type)
-
-        except yaml.constructor.ConstructorError, e:
-            yaml_error(loader, e)
-        except Exception, e:
-            yaml_error(loader, yaml.constructor.ConstructorError(
-                None, None,
-                "Unable to deserialize %s object (param %s): %s" % (cls.__name__, key_node.value, e),
-                value_node.start_mark), exc_info=sys.exc_info())
-
-    return params
-
-
-def represent_zenpackspec(dumper, obj):
-    return represent_spec(dumper, obj, yaml_tag=u'!ZenPackSpec')
-
-
-def construct_zenpackspec(loader, node):
-    # create a unique log for this ZenPack
-    name = find_name_from_node(loader)
-    if name:
-        log = ZPLOG.add_log(name, QUIET, LEVEL)
-        # set the global LOG variable to ths instance for things like YAML errors
-        global LOG
-        LOG = log
-
-    from spec.ZenPackSpec import ZenPackSpec
-
-    params = construct_spec(ZenPackSpec, loader, node)
-    name = params.pop("name")
-    params['log'] = LOG
-
-    fatal = not getattr(loader, 'warnings', False)
-    yaml_errored = getattr(loader, 'yaml_errored', False)
-
-    try:
-        return ZenPackSpec(name, **params)
-    except Exception, e:
-        if yaml_errored and not fatal:
-            LOG.error("(possibly because of earlier errors) %s" % e)
-        else:
-            raise
-
-    return None
-
-def find_name_from_node(loader):
-    '''determine zenpack name'''
-    for k in loader.recursive_objects.keys():
-        for v in k.value:
-            if isinstance(v, tuple) and len(v) == 2:
-                key, value = str(v[0].value), str(v[1].value)
-                if key == 'name':
-                    return value
-    return None
-
-def relname_from_classname(classname, plural=False):
-    """Return relationship name given classname and plural flag."""
-
-    if '.' in classname:
-        classname = classname.replace('.', '_').lower()
-
-    relname = list(classname)
-    for i, c in enumerate(classname):
-        if relname[i].isupper():
-            relname[i] = relname[i].lower()
-        else:
-            break
-
-    return ''.join((''.join(relname), 's' if plural else ''))
-
 
 #### Deprecated? These appear to be unused 
 
@@ -1030,13 +312,4 @@ def update(d, u):
         else:
             d[k] = u[k]
     return d
-
-
-def class_to_str(class_):
-    return class_.__module__ + "." + class_.__name__
-
-
-def construct_relschemaspec(loader, node):
-    schemastr = str(loader.construct_scalar(node))
-    return str_to_relschemaspec(schemastr)
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -1,4 +1,24 @@
 import yaml
+import re
+from yaml.representer import SafeRepresenter
+from collections import OrderedDict
+from ..functions import LOG
+
+
+def get_zproperty_type(z_type):
+    """
+        For zproperties, the actual data type of a default value
+        depends on the defined type of the zProperty.
+    """
+    map = {'boolean': 'bool',
+           'int': 'int',
+           'float': 'float',
+           'string': 'str',
+           'password': 'str',
+           'lines': 'list(str)'
+    }
+    return map.get(z_type, 'str')
+
 
 class Dumper(yaml.Dumper):
     """
@@ -7,4 +27,262 @@ class Dumper(yaml.Dumper):
         and its own dumper (for add_representer) so that the proper methods will
         be used for this specific zenpacklib.
     """
-    pass
+
+    LOG=LOG
+
+    def dict_representer(self, data):
+        return yaml.MappingNode(u'tag:yaml.org,2002:map', data.items())
+
+    def get_representation(self, value, v_type):
+        ''''''
+        map = {'bool': self.represent_bool,
+               'float': self.represent_float,
+               'int': self.represent_int,
+               'str': self.represent_str,
+               }
+
+        if v_type in map.keys():
+            return map.get(v_type)(value)
+        elif v_type.startswith("dict"):
+            return self.represent_dict(value)
+        elif v_type.startswith('list'):
+            if 'ExtraPath' in v_type:
+                # Represent this as a list of lists of quoted strings (each on one line).
+                paths = []
+                for path in list(value):
+                    # Force the regular expressions to be quoted, so we don't have any issues with that.
+                    pathnodes = [self.represent_scalar(u'tag:yaml.org,2002:str', x, style="'") for x in path]
+                    paths.append(yaml.SequenceNode(u'tag:yaml.org,2002:seq', pathnodes, flow_style=True))
+                return yaml.SequenceNode(u'tag:yaml.org,2002:seq', paths, flow_style=False)
+            elif 'class' in v_type:
+                # The "class" in this context is either a class reference or
+                # a class name (string) that refers to a class defined in
+                # this ZenPackSpec.
+                classes = [isinstance(x, type) and self.class_to_str(x) or x for x in value]
+                return self.represent_list(classes)
+            else:
+                return self.represent_list(value)
+        elif v_type == 'RelationshipSchemaSpec':
+            return self.represent_str(self.relschemaspec_to_str(value))
+        elif v_type == 'Severity':
+            return self.represent_str(self.severity_to_str(value))
+        else:
+            
+            m = re.match('^SpecsParameter\((.*)\)$', v_type)
+            if m:
+                spectype = m.group(1)
+                specmapping = OrderedDict()
+                defaults = value.get('DEFAULTS', None)
+                if defaults:
+                    value.pop('DEFAULTS')
+                for key, spec in value.items():
+                    if type(spec).__name__ != spectype:
+                        raise yaml.representer.RepresenterError(
+                            "Unable to serialize {} object ({}):  Expected an object of type {}".format(
+                            type(spec).__name__, key, spectype))
+                    else:
+                        specmapping[self.represent_str(key)] = self.represent_spec(spec, defaults=defaults)
+                return self.dict_representer(specmapping)
+
+            else:
+                self.LOG.info("Using represent_data for {} ({})".format(value, v_type))
+                return self.represent_data(value)
+
+        return None
+
+    def represent_relschemaspec(self, data):
+        """
+        Generic representer for serializing relation specs to YAML.
+        """
+        return self.represent_str(self.relschemaspec_to_str(data))
+
+    def represent_zenpackspec(self, obj):
+        """
+        Generic representer for serializing ZenPack specs to YAML.
+        """
+        return self.represent_spec(obj, yaml_tag=u'!ZenPackSpec')
+
+    def represent_spec(self, obj, yaml_tag=u'tag:yaml.org,2002:map', defaults=None):
+        """
+        Generic representer for serializing specs to YAML.  Rather than using
+        the default PyYAML representer for python objects, we very carefully
+        build up the YAML according to the parameter definitions in the __init__
+        of each spec class.  This same format is used by construct_spec (the YAML
+        constructor) to ensure that the spec objects are built consistently,
+        whether it is done via YAML or the API.
+        """
+        from ..spec.RRDDatapointSpec import RRDDatapointSpec
+        cls = obj.__class__
+        if isinstance(obj, RRDDatapointSpec) and obj.shorthand:
+            # Special case- we allow for a shorthand in specifying datapoints
+            # as specs as strings rather than explicitly as a map.
+            return self.represent_str(str(obj.shorthand))
+
+        mapping = OrderedDict()
+
+        param_defs = cls.init_params()
+
+        for p_name, p_data in param_defs.iteritems():
+            # determine what type of object this is
+            type_ = p_data.get('type')
+
+            try:
+                value = getattr(obj, p_name)
+            except AttributeError:
+                raise yaml.representer.RepresenterError(
+                    "Unable to serialize {} object: {}, a supported parameter, is not accessible as a property.".format(
+                    cls.__name__, p_name))
+                continue
+
+            # Figure out what the default value is.  First, consider the default
+            # value for this parameter (globally):
+            default_value = p_data.get('default', None)
+
+            # Now, we need to handle 'DEFAULTS'.  If we're in a situation
+            # where that is supported, and we're outputting a spec that
+            # would be affected by it (not DEFAULTS itself, in other words),
+            # then we look at the default value for this parameter, in case
+            # it has changed the global default for this parameter.
+            if hasattr(obj, 'name') and obj.name != 'DEFAULTS' and defaults is not None:
+                default_value = getattr(defaults, p_name, default_value)
+
+            # If the value is a default value, we can omit it from the export.
+            if value == default_value:
+                continue
+
+            # If the value is null and the type is a list or dictionary, we can
+            # assume it was some optional nested data and omit it.
+            if value is None and (type_.startswith('dict') or type_.startswith('list') or type_.startswith('SpecsParameter')):
+                continue
+
+            if type_ == 'ZPropertyDefaultValue':
+                # For zproperties, the actual data type of a default value
+                # depends on the defined type of the zProperty.
+                type_ = get_zproperty_type(obj.type_)
+
+            yaml_param = self.represent_str(p_data.get('yaml_param'))
+            try:
+                if type_ == 'ExtraParams':
+                    # ExtraParams is a special case, where any 'extra'
+                    # parameters not otherwise defined in the init_params
+                    # definition are tacked into a dictionary with no specific
+                    # schema validation.  This is meant to be used in situations
+                    # where it is impossible to know what parameters will be
+                    # needed ahead of time, such as with a datasource
+                    # that has been subclassed and had new properties added.
+                    #
+                    # Note: the extra parameters are required to have scalar
+                    # values only.
+                    for extra_param in value:
+                        # add any values from an extraparams dict onto the spec's parameter list directly.
+                        yaml_extra_param = self.represent_str(extra_param)
+                        mapping[yaml_extra_param] = self.represent_data(value[extra_param])
+                else:
+                    mapping[yaml_param] = self.get_representation(value, type_)
+
+            except yaml.representer.RepresenterError:
+                raise
+            except Exception, e:
+                raise yaml.representer.RepresenterError(
+                    "Unable to serialize {} object (param {}, type {}, value {}): {}".format(
+                    cls.__name__, p_name, type_, value, e))
+
+            if p_name in param_defs and p_data.get('yaml_block_style'):
+                mapping[yaml_param].flow_style = False
+
+        # Return a node describing the mapping (dictionary) of the params
+        # used to build this spec.
+        node = yaml.MappingNode(yaml_tag, mapping.items())
+        return node
+
+    def represent_ordereddict(self, data):
+        value = []
+        for item_key, item_value in data.items():
+            node_key = self.represent_data(item_key)
+            node_value = self.represent_data(item_value)
+            value.append((node_key, node_value))
+        return yaml.MappingNode(u'tag:yaml.org,2002:map', value)
+
+    def relschemaspec_to_str(self, spec):
+        # Omit relation names that are their defaults.
+        left_optrelname = "" if spec.left_relname == spec.default_left_relname else "({})".format(spec.left_relname)
+        right_optrelname = "" if spec.right_relname == spec.default_right_relname else "({})".format(spec.right_relname)
+
+        return "{}{} {}:{} {}{}".format(
+            spec.left_class,
+            left_optrelname,
+            spec.left_cardinality,
+            spec.right_cardinality,
+            right_optrelname,
+            spec.right_class
+        )
+
+    def severity_to_str(self, value):
+        '''
+        Return string representation for severity given a numeric value.
+        '''
+        severity = {
+            5: 'crit',
+            4: 'err',
+            3: 'warn',
+            2: 'info',
+            1: 'debug',
+            0: 'clear'
+            }.get(value, None)
+
+        if severity is None:
+            raise ValueError("'{}' is not a valid value for severity.".format(value))
+
+        return severity
+
+    def class_to_str(self, class_):
+        return class_.__module__ + "." + class_.__name__
+
+
+from ..spec.ZenPackSpec import ZenPackSpec
+from ..spec.DeviceClassSpec import DeviceClassSpec
+from ..spec.ZPropertySpec import ZPropertySpec
+from ..spec.ClassSpec import ClassSpec
+from ..spec.ClassPropertySpec import ClassPropertySpec
+from ..spec.ClassRelationshipSpec import ClassRelationshipSpec
+from ..spec.RelationshipSchemaSpec import RelationshipSchemaSpec
+
+from ..params.ZenPackSpecParams import ZenPackSpecParams
+from ..params.DeviceClassSpecParams import DeviceClassSpecParams
+from ..params.ZPropertySpecParams import ZPropertySpecParams
+from ..params.ClassSpecParams import ClassSpecParams
+from ..params.ClassPropertySpecParams import ClassPropertySpecParams
+from ..params.ClassRelationshipSpecParams import ClassRelationshipSpecParams
+from ..params.RRDTemplateSpecParams import RRDTemplateSpecParams
+from ..params.RRDThresholdSpecParams import RRDThresholdSpecParams
+from ..params.RRDDatasourceSpecParams import RRDDatasourceSpecParams
+from ..params.RRDDatapointSpecParams import RRDDatapointSpecParams
+from ..params.GraphDefinitionSpecParams import GraphDefinitionSpecParams
+from ..params.GraphPointSpecParams import GraphPointSpecParams
+
+# Spec subclasses
+Dumper.add_representer(ZenPackSpec, Dumper.represent_zenpackspec)
+Dumper.add_representer(DeviceClassSpec, Dumper.represent_spec)
+Dumper.add_representer(ZPropertySpec, Dumper.represent_spec)
+Dumper.add_representer(ClassSpec, Dumper.represent_spec)
+Dumper.add_representer(ClassPropertySpec, Dumper.represent_spec)
+Dumper.add_representer(ClassRelationshipSpec, Dumper.represent_spec)
+Dumper.add_representer(RelationshipSchemaSpec, Dumper.represent_relschemaspec)
+# SpecParams subclasses
+Dumper.add_representer(ZenPackSpecParams, Dumper.represent_zenpackspec)
+Dumper.add_representer(DeviceClassSpecParams, Dumper.represent_spec)
+Dumper.add_representer(ZPropertySpecParams, Dumper.represent_spec)
+Dumper.add_representer(ClassSpecParams, Dumper.represent_spec)
+Dumper.add_representer(ClassPropertySpecParams, Dumper.represent_spec)
+Dumper.add_representer(ClassRelationshipSpecParams, Dumper.represent_spec)
+Dumper.add_representer(RRDTemplateSpecParams, Dumper.represent_spec)
+Dumper.add_representer(RRDThresholdSpecParams, Dumper.represent_spec)
+Dumper.add_representer(RRDDatasourceSpecParams, Dumper.represent_spec)
+Dumper.add_representer(RRDDatapointSpecParams, Dumper.represent_spec)
+Dumper.add_representer(GraphDefinitionSpecParams, Dumper.represent_spec)
+Dumper.add_representer(GraphPointSpecParams, Dumper.represent_spec)
+# representers for python types
+Dumper.add_representer(OrderedDict, Dumper.represent_ordereddict)
+Dumper.add_representer(unicode, SafeRepresenter.represent_unicode)
+
+

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
@@ -1,4 +1,14 @@
 import yaml
+import os
+import re
+import sys
+import importlib
+import keyword
+from collections import OrderedDict
+from ..functions import ZENOSS_KEYWORDS, JS_WORDS, relname_from_classname, find_keyword_cls
+from .ZenPackLibLog import ZPLOG, LOG
+from .Dumper import get_zproperty_type
+
 
 class Loader(yaml.Loader):
     """
@@ -7,4 +17,449 @@ class Loader(yaml.Loader):
         and its own dumper (for add_representer) so that the proper methods will
         be used for this specific zenpacklib.
     """
-    pass
+
+    LOG=LOG
+    QUIET=False
+    LEVEL=0
+
+    def type_map(self, node):
+        '''map yaml node to python data type'''
+        map = {'int': int,
+               'float': float, 
+               'str': str,
+               'unicode': unicode,
+               'bool': bool,
+               'binary': str,
+               'set': set,
+               'seq': list,
+               'map': dict}
+        if 'null' in node.tag:
+            return None
+        for k in map.keys():
+            if k in node.tag:
+                try:
+                    return map.get(k,'str')(node.value)
+                except:
+                    pass
+        return self.construct_scalar(node)
+
+    def dict_constructor(self, node):
+        """constructor for OrderedDict"""
+        return OrderedDict(self.construct_pairs(node))
+
+    def construct_specsparameters(self, node, spectype):
+        """constructor for SpecsParameters"""
+        from ..spec.Spec import Spec
+        spec_class = {x.__name__: x for x in Spec.__subclasses__()}.get(spectype, None)
+
+        if not spec_class:
+            self.yaml_error(yaml.constructor.ConstructorError(
+                None, None,
+                "Unrecognized Spec class {}".format(spectype),
+                node.start_mark))
+            return
+
+        if not isinstance(node, yaml.MappingNode):
+            self.yaml_error(yaml.constructor.ConstructorError(
+                None, None,
+                "expected a mapping node, but found {}".format(node.id),
+                node.start_mark))
+            return
+
+        param_defs = spec_class.init_params()
+        specs = OrderedDict()
+        for spec_key_node, spec_value_node in node.value:
+            try:
+                spec_key = str(self.construct_scalar(spec_key_node))
+                self.verify_key(spec_class, param_defs, spec_key, spec_key_node.start_mark)
+
+            except yaml.MarkedYAMLError, e:
+                self.yaml_error(e)
+
+            specs[spec_key] = self.construct_spec(spec_class, spec_value_node)
+
+        return specs
+
+    def construct_spec(self, cls, node):
+        """
+        Generic constructor for deserializing specs from YAML.   Should be
+        the opposite of represent_spec, and works in the same manner (with its
+        parsing and validation directed by the init_params of each spec class)
+        """
+        from ..spec.RRDDatapointSpec import RRDDatapointSpec
+        if issubclass(cls, RRDDatapointSpec) and isinstance(node, yaml.ScalarNode):
+            # Special case- we allow for a shorthand in specifying datapoint specs.
+            return dict(shorthand=self.construct_scalar(node))
+
+        param_defs = cls.init_params()
+        params = {}
+        if not isinstance(node, yaml.MappingNode):
+            self.yaml_error(yaml.constructor.ConstructorError(
+                None, None,
+                "expected a mapping node, but found {}".format(node.id),
+                node.start_mark))
+
+        params['_source_location'] = "{}: {}-{}".format(
+            os.path.basename(node.start_mark.name),
+            node.start_mark.line+1,
+            node.end_mark.line+1)
+
+        # TODO: When deserializing, we should check if required properties are present.
+
+        param_name_map = {}
+        for param in param_defs:
+            param_name_map[param_defs[param]['yaml_param']] = param
+
+        extra_params = None
+        for key in param_defs:
+            if param_defs[key]['type'] == 'ExtraParams':
+                if extra_params:
+                    self.yaml_error(yaml.constructor.ConstructorError(
+                        None, None,
+                        "Only one ExtraParams parameter may be specified.",
+                        node.start_mark))
+                extra_params = key
+                params[extra_params] = {}
+
+        for key_node, value_node in node.value:
+            yaml_key = str(self.construct_scalar(key_node))
+            self.verify_key(cls, param_defs, yaml_key, key_node.start_mark)
+
+            if yaml_key not in param_name_map:
+                if extra_params:
+                    # If an 'extra_params' parameter is defined for this spec,
+                    # we take all unrecognized paramters and stuff them into
+                    # a single parameter, which is a dictonary of "extra" parameters.
+                    #
+                    # Note that the values of these extra parameters need to be
+                    # scalars, not nested maps or something like that.
+                    #params[extra_params][yaml_key] = self.construct_scalar(value_node)
+                    params[extra_params][yaml_key] = self.type_map(value_node)
+                    continue
+                else:
+                    self.yaml_error(yaml.constructor.ConstructorError(
+                        None, None,
+                        "Unrecognized parameter '{}' found while processing {}".format(yaml_key, cls.__name__),
+                        key_node.start_mark))
+                    continue
+
+            key = param_name_map[yaml_key]
+            expected_type = param_defs[key]['type']
+
+            if expected_type == 'ZPropertyDefaultValue':
+                # For zproperties, the actual data type of a default value
+                # depends on the defined type of the zProperty.
+
+                try:
+                    zPropType = [x[1].value for x in node.value if x[0].value == 'type'][0]
+                except Exception:
+                    # type was not specified, so we assume the default (string)
+                    zPropType = 'string'
+
+                try:
+                    expected_type = get_zproperty_type(zPropType)
+
+                except KeyError:
+                    self.yaml_error(yaml.constructor.ConstructorError(
+                        None, None,
+                        "Invalid zProperty type_ '{}' for property {} found while processing {}".format(zPropType, key, cls.__name__),
+                        key_node.start_mark))
+                    continue
+
+            try:
+                if expected_type == "bool":
+                    params[key] = self.construct_yaml_bool(value_node)
+                elif expected_type.startswith("dict(SpecsParameter("):
+                    m = re.match('^dict\(SpecsParameter\((.*)\)\)$', expected_type)
+                    if m:
+                        spectype = m.group(1)
+
+                        if not isinstance(node, yaml.MappingNode):
+                            self.yaml_error(yaml.constructor.ConstructorError(
+                                None, None,
+                                "expected a mapping node, but found {}".format(node.id),
+                                node.start_mark))
+                            continue
+                        specs = OrderedDict()
+                        for spec_key_node, spec_value_node in value_node.value:
+                            spec_key = str(self.construct_scalar(spec_key_node))
+
+                            specs[spec_key] = self.construct_specsparameters(spec_value_node, spectype)
+                        params[key] = specs
+                    else:
+                        raise Exception("Unable to determine specs parameter type in '{}'".format(expected_type))
+                elif expected_type.startswith("dict"):
+                    params[key] = self.construct_mapping(value_node)
+                elif expected_type == "float":
+                    params[key] = float(self.construct_scalar(value_node))
+                elif expected_type == "int":
+                    params[key] = int(self.construct_scalar(value_node))
+                elif expected_type == "list(class)":
+                    classnames = self.construct_sequence(value_node)
+                    classes = []
+                    for c in classnames:
+                        class_ = self.str_to_class(c)
+                        if class_ is None:
+                            # local reference to a class being defined in
+                            # this zenpack.  (ideally we should verify that
+                            # the name is valid, but this is not possible
+                            # in a one-pass parsing of the yaml).
+                            classes.append(c)
+                        else:
+                            classes.append(class_)
+                    # ZPL defines "class" as either a string representing a
+                    # class in this definition, or a class object representing
+                    # an external class.
+                    params[key] = classes
+                elif expected_type == 'list(ExtraPath)':
+                    if not isinstance(value_node, yaml.SequenceNode):
+                        raise yaml.constructor.ConstructorError(
+                            None, None,
+                            "expected a sequence node, but found {}".format(value_node.id),
+                            value_node.start_mark)
+                    extra_paths = []
+                    for path_node in value_node.value:
+                        extra_paths.append(self.construct_sequence(path_node))
+                    params[key] = extra_paths
+                elif expected_type == "list(RelationshipSchemaSpec)":
+                    schemaspecs = []
+                    for s in self.construct_sequence(value_node):
+                        schemaspecs.append(self.str_to_relschemaspec(s))
+                    params[key] = schemaspecs
+                elif expected_type.startswith("list"):
+                    params[key] = self.construct_sequence(value_node)
+                elif expected_type == "str":
+                    params[key] = str(self.construct_scalar(value_node))
+                elif expected_type == 'RelationshipSchemaSpec':
+                    schemastr = str(self.construct_scalar(value_node))
+                    params[key] = self.str_to_relschemaspec(schemastr)
+                elif expected_type == 'Severity':
+                    severitystr = str(self.construct_scalar(value_node))
+                    params[key] = self.str_to_severity(severitystr)
+                else:
+                    m = re.match('^SpecsParameter\((.*)\)$', expected_type)
+                    if m:
+                        spectype = m.group(1)
+                        params[key] = self.construct_specsparameters(value_node, spectype)
+                    else:
+                        raise Exception("Unhandled type '{}'".format(expected_type))
+
+            except yaml.constructor.ConstructorError, e:
+                self.yaml_error(e)
+            except Exception, e:
+                self.yaml_error(yaml.constructor.ConstructorError(
+                    None, None,
+                    "Unable to deserialize {} object (param {}): {}".format(cls.__name__, key_node.value, e),
+                    value_node.start_mark), exc_info=sys.exc_info())
+
+        return params
+
+    def construct_zenpackspec(self, node):
+        """"""
+        log_name = self.find_name_from_node()
+        if log_name:
+            self.LOG = ZPLOG.add_log(log_name, quiet=self.QUIET, level=self.LEVEL)
+
+        from ..spec.ZenPackSpec import ZenPackSpec
+        params = self.construct_spec(ZenPackSpec, node)
+        params['log'] = self.LOG
+        name = params.pop("name")
+
+        fatal = not getattr(self, 'warnings', False)
+        yaml_errored = getattr(self, 'yaml_errored', False)
+
+        try:
+            return ZenPackSpec(name, **params)
+        except Exception, e:
+            if yaml_errored and not fatal:
+                self.LOG.error("(possibly because of earlier errors) {}".format(e))
+            else:
+                raise
+
+        return None
+
+    def construct_relschemaspec(self, node):
+        """"""
+        schemastr = str(self.construct_scalar(node))
+        return self.str_to_relschemaspec(schemastr)
+
+    def str_to_class(self, classstr):
+        if classstr == 'object':
+            return object
+
+        if "." not in classstr:
+            # TODO: Support non qualfied class names, searching zenpack, zenpacklib,
+            # and ZenModel namespaces
+
+            # An unqualified class name is assumed to be referring to one in
+            # the classes defined in this ZenPackSpec.   We can't validate this,
+            # or return a class object for it, if this is the case.  So we
+            # return no class object, and the caller will assume that it
+            # it refers to a class being defined.
+            return None
+
+        modname, classname = classstr.rsplit(".", 1)
+        # ensure that 'zenpacklib' refers to *this* zenpacklib, if more than
+        # one is loaded in the system.
+        if modname in ['zenpacklib', 'ZenPacks.zenoss.ZenPackLib.lib.factory.ModelTypeFactory']:
+            modname = 'ZenPacks.zenoss.ZenPackLib.zenpacklib'
+        try:
+            class_ = getattr(importlib.import_module(modname), classname)
+        except Exception, e:
+            raise ValueError("Class '{}' is not valid: {}".format(classstr, e))
+
+        return class_
+
+    def str_to_relschemaspec(self, schemastr):
+        schema_pattern = re.compile(
+            r'^\s*(?P<left>\S+)'
+            r'\s+(?P<cardinality>1:1|1:M|1:MC|M:M)'
+            r'\s+(?P<right>\S+)\s*$',
+        )
+
+        class_rel_pattern = re.compile(
+            r'(\((?P<pre_relname>[^\)\s]+)\))?'
+            r'(?P<class>[^\(\s]+)'
+            r'(\((?P<post_relname>[^\)\s]+)\))?'
+        )
+
+        m = schema_pattern.search(schemastr)
+        if not m:
+            raise ValueError("RelationshipSchemaSpec '{}' is not valid" .format(schemastr))
+
+        ml = class_rel_pattern.search(m.group('left'))
+        if not ml:
+            raise ValueError("RelationshipSchemaSpec '{}' left side is not valid".format(m.group('left')))
+
+        mr = class_rel_pattern.search(m.group('right'))
+        if not mr:
+            raise ValueError("RelationshipSchemaSpec '{}' right side is not valid".format(m.group('right')))
+
+        reltypes = {
+            '1:1': ('ToOne', 'ToOne'),
+            '1:M': ('ToMany', 'ToOne'),
+            '1:MC': ('ToManyCont', 'ToOne'),
+            'M:M': ('ToMany', 'ToMany')
+        }
+
+        left_class = ml.group('class')
+        right_class = mr.group('class')
+        left_type = reltypes.get(m.group('cardinality'))[0]
+        right_type = reltypes.get(m.group('cardinality'))[1]
+
+        left_relname = ml.group('pre_relname') or ml.group('post_relname')
+        if left_relname is None:
+            left_relname = relname_from_classname(right_class, plural=left_type != 'ToOne')
+
+        right_relname = mr.group('pre_relname') or mr.group('post_relname')
+        if right_relname is None:
+            right_relname = relname_from_classname(left_class, plural=right_type != 'ToOne')
+
+        return dict(
+            left_class=left_class,
+            left_relname=left_relname,
+            left_type=left_type,
+            right_type=right_type,
+            right_class=right_class,
+            right_relname=right_relname
+        )
+
+    def str_to_severity(self, value):
+        '''
+        Return numeric severity given a string representation of severity.
+        '''
+        try:
+            severity = int(value)
+        except (TypeError, ValueError):
+            severity = {
+                'crit': 5, 'critical': 5,
+                'err': 4, 'error': 4,
+                'warn': 3, 'warning': 3,
+                'info': 2, 'information': 2, 'informational': 2,
+                'debug': 1, 'debugging': 1,
+                'clear': 0,
+                }.get(value.lower())
+
+        if severity is None:
+            raise ValueError("'{}' is not a valid value for severity.".format(value))
+
+        return severity
+
+    def format_message(self, e):
+        message = []
+
+        mark = e.context_mark or e.problem_mark
+        if mark:
+            position = "{}:{}:{}".format(mark.name, mark.line + 1, mark.column + 1)
+        else:
+            position = "[unknown]"
+        if e.context is not None:
+            message.append(e.context)
+
+        if e.problem is not None:
+            message.append(e.problem)
+
+        if e.note is not None:
+            message.append("(note: {})".format(e.note))
+
+        return "{}: {}".format(position, message)
+
+    def yaml_warning(self, e):
+        # Given a MarkedYAMLError exception, either log or raise
+        # the error, depending on the 'fatal' argument.
+        self.LOG.warn(self.format_message(e))
+
+    def yaml_error(self, e, exc_info=None):
+        # Given a MarkedYAMLError exception, either log or raise
+        # the error, depending on the 'fatal' argument.
+        fatal = not getattr(self, 'warnings', False)
+        setattr(self, 'yaml_errored', True)
+        if exc_info:
+            # When we're given the original exception (which was wrapped in
+            # a MarkedYAMLError), we can provide more context for debugging.
+            from traceback import format_exc
+            e.note = "\nOriginal exception:\n{}".format(format_exc(exc_info))
+        if fatal:
+            raise e
+        self.LOG.error(self.format_message(e))
+
+    def verify_key(self, cls, params, key, start_mark):
+        # always ok to use a param name (description, name, etc.)
+        if key in params.keys():
+            return True
+        # never use a python reserved word
+        if key in keyword.kwlist:
+            self.yaml_error(yaml.constructor.ConstructorError(
+                None, None,
+                "Found reserved keyword '{}' while processing {}".format(key, cls.__name__),
+                start_mark))
+        elif key in ZENOSS_KEYWORDS.union(JS_WORDS):
+            # should be ok to use a zenoss word to define these
+            # some items, like sysUpTime are pretty common datapoints
+            if cls.__name__ not in ['RRDDatasourceSpec',
+                                    'RRDDatapointSpec',
+                                    'RRDTemplateSpec',
+                                    'GraphDefinitionSpec',
+                                    'GraphPointSpec']:
+                klasses = ', '.join(find_keyword_cls(key))
+                self.yaml_warning(yaml.constructor.ConstructorError(
+                    None, None,
+                    "Found reserved Zenoss keyword '{}' from {}".format(key, klasses),
+                    start_mark))
+        return False
+
+    def find_name_from_node(self):
+        '''determine zenpack name'''
+        for k in self.recursive_objects.keys():
+            for v in k.value:
+                if isinstance(v, tuple) and len(v) == 2:
+                    key, value = str(v[0].value), str(v[1].value)
+                    if key == 'name':
+                        return value
+        return None
+
+
+Loader.add_constructor(u'tag:yaml.org,2002:map', Loader.dict_constructor)
+Loader.add_constructor(u'!ZenPackSpec', Loader.construct_zenpackspec)
+yaml.add_path_resolver(u'!ZenPackSpec', [], Loader=Loader)
+

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/ZenPackLibLog.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/ZenPackLibLog.py
@@ -1,5 +1,6 @@
 import logging
 
+
 def new_log(id):
     '''create and return a new log file'''
     log = logging.getLogger(id)
@@ -14,11 +15,13 @@ def new_log(id):
         logging.basicConfig()
     return log
 
+LOG = new_log('zpl.zenpacklib')
+
 
 class ZenPackLibLog(object):
     ''''''
     zenpacks = {}
-    defaultlog = new_log('zpl.zenpacklib')
+    defaultlog = LOG
 
     def get_log(self, id):
         if id in self.zenpacks.keys():
@@ -35,5 +38,8 @@ class ZenPackLibLog(object):
             # set to error if quiet is True (default)
             log.setLevel('ERROR' if quiet else level)
             self.zenpacks[id] = {'log': log, 'quiet': quiet, 'level':level}
-        self.defaultlog.info("Added {} (level {})".format(id, log.level))
+        else:
+            log = self.get_log(id)
         return log
+
+ZPLOG = ZenPackLibLog()

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
@@ -24,7 +24,6 @@ YAML_PREFERRED_ORDER = ['zProperties', 'class_relationships', 'classes',
 
 def get_calling_dir():
     '''determine source directory of ZenPack's load_yaml call'''
-    frame = inspect.stack()[1]
     for i in inspect.stack():
         frame, filename, lineno, method_name, lines, idx = i
         if '__init__.py' not in filename:

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
@@ -1,0 +1,256 @@
+import os
+import logging
+from collections import OrderedDict
+import yaml
+import time
+from .ZenPackLibLog import LOG
+from .Dumper import Dumper
+from .Loader import Loader
+
+
+# list of yaml sections with DEFAULTS capability
+YAML_HAS_DEFAULTS = ['classes', 'properties', 'thresholds', 'datasources',
+                     'datapoints', 'graphs', 'relationships','graphpoints']
+
+# preferred section ordering for YAML sections
+YAML_PREFERRED_ORDER = ['zProperties', 'class_relationships', 'classes',
+                        'device_classes', 'DEFAULTS', 'base',
+                        'label', 'order', 'properties',
+                        'monitoring_templates', 'dynamicview_views',
+                        'dynamicview_relations', 'impacts', 'impacted_by',
+                        'relationships']
+
+
+def load_yaml(yaml_doc=None, verbose=False, level=0):
+    ''''''
+    Loader.QUIET= not verbose
+    Loader.LEVEL = level
+
+    if not yaml_doc:
+        LOG.error("No YAML file specified")
+        return
+
+    # loading from multiple files
+    if isinstance(yaml_doc, list):
+        # build python dict of merged YAML data
+        cfg_data = {}
+        # this is to make sure ZP names don't conflict
+        zp_id = None
+        for f in yaml_doc:
+            # load as a raw Python dictionary
+            f_cfg = load_yaml_single(f, useLoader=False)
+            name = f_cfg.get('name')
+            if not zp_id:
+                zp_id = name
+            else:
+                # if we already have a ZP id, but this yaml
+                # has a different one, then there's a problem.
+                if name and name != zp_id:
+                    LOG.error('Skipping {} because multiple ZenPack names found: {} vs {}'.format(f, zp_id, name))
+                    continue
+            # update the python dict
+            cfg_data.update(f_cfg)
+        # once loaded, optimize
+        optimized_yaml = get_optimized_yaml(cfg_data)
+        # resubmit merged YAML
+        return load_yaml(optimized_yaml, verbose, level)
+
+    else:
+        # load all YAML files in a directory
+        if os.path.isdir(yaml_doc):
+            files = []
+            for f in os.listdir(yaml_doc):
+                if '.yaml' not in f:
+                    continue
+                files.append('{}/{}'.format(yaml_doc, f))
+            # resubmit multiple files
+            return load_yaml(files, verbose, level)
+
+    # load YAML and create ZenPackSpec
+    start = time.time()
+    CFG = None
+
+    try:
+        LOG.info("Loading YAML from {}".format(yaml_doc))
+        CFG = load_yaml_single(yaml_doc)
+    except Exception as e:
+        LOG.error(e)
+
+    if CFG:
+        CFG.create()
+    else:
+        LOG.error("Unable to load {}".format(yaml_doc))
+
+    end = time.time() - start
+    LOG.info("Loaded {} in {:0.2f}s".format(yaml_doc, end))
+
+    return CFG
+
+
+def load_yaml_single(yaml_doc, useLoader=True):
+    ''''''
+    # if it's a string
+    if os.path.isfile(yaml_doc):
+        if useLoader:
+            return yaml.load(file(yaml_doc, 'r'), Loader=Loader)
+        return yaml.load(file(yaml_doc, 'r'))
+    else:
+        if useLoader:
+            return yaml.load(yaml_doc, Loader=Loader)
+        return yaml.load(yaml_doc)
+
+
+def optimize_yaml(yaml_doc):
+    """optimize layout of YAML file"""
+    # apply log verbosity settings
+    Loader.QUIET= False
+    Loader.LEVEL = 0
+    # original load
+    CFG = load_yaml(yaml_doc)
+    CFG.create()
+    # original yaml dump
+    orig_yaml = yaml.dump(CFG.specparams, Dumper=Dumper)
+    # load original yaml back as a Python dictionary
+    data = load_yaml_single(orig_yaml, useLoader=False)
+    # optimized output
+    optimized_yaml = get_optimized_yaml(data)
+    # new load
+    valid = compare_zenpackspecs(orig_yaml, optimized_yaml)
+    if not valid:
+        LOG.warn('OPTIMIZATION FAILED VERIFICATION!  Please review optimized YAML prior to use ')
+    return optimized_yaml
+
+
+def compare_zenpackspecs(orig_yaml, new_yaml):
+    """report whether different YAML documents are identical"""
+    # now load both yaml files and create ZenPackSpec configs
+    # apply log verbosity settings
+    Loader.QUIET= False
+    Loader.LEVEL = 0
+    orig = load_yaml_single(orig_yaml)
+    new = load_yaml_single(new_yaml)
+    orig.create()
+    new.create()
+    # SpecParams should be equal
+    if orig != new:
+        LOG.warn('ZenPackSpec mismatch between original and new')
+        dict_compare(orig.__dict__, new.__dict__)
+    # now dump new specs back out to yaml
+    orig_dump = yaml.dump(orig.specparams, Dumper=Dumper)
+    new_dump = yaml.dump(new.specparams, Dumper=Dumper)
+    # load raw yaml into Python dictionaries
+    orig_raw_yaml = load_yaml_single(orig_dump, useLoader=False)
+    new_raw_yaml = load_yaml_single(new_dump, useLoader=False)
+    # these should also be equivalent
+    if orig_raw_yaml != new_raw_yaml:
+        LOG.warn('YAML loaded Python dictionary mismatch between original and new')
+        dict_compare(orig_raw_yaml, new_raw_yaml)
+        return False
+    return True
+
+def dict_compare(d1, d2):
+    d1_keys = set(d1.keys())
+    d2_keys = set(d2.keys())
+    intersect_keys = d1_keys.intersection(d2_keys)
+    added = d1_keys - d2_keys
+    removed = d2_keys - d1_keys
+    modified = {o : (d1[o], d2[o]) for o in intersect_keys if d1[o] != d2[o]}
+    same = set(o for o in intersect_keys if d1[o] == d2[o])
+    LOG.warn('ADDED: {}'.format(added))
+    LOG.warn('REMOVED: {}'.format(removed))
+    LOG.warn('MODIFIED: {}'.format(modified))
+
+
+def get_optimized_yaml(data):
+    """
+        return optimized YAML representing ZenPackSpec
+    """
+    # set DEFAULTS throughout
+    descend_defaults(data)
+    # sort
+    ordered = sort_yaml_data(data)
+    # optimized output
+    return yaml.dump(ordered,  default_flow_style=False, Dumper=Dumper).replace('!!map','')
+
+
+def descend_defaults(input):
+    """
+        descend YAML dictionary and optimize DEFAULTS
+    """
+    for k, v in input.items():
+        if not isinstance(v, dict):
+            continue
+        if k == 'DEFAULTS': 
+            continue
+        if k in YAML_HAS_DEFAULTS:
+            if len(v.keys()) > 1:
+                set_defaults(v)
+        descend_defaults(v)
+
+
+def set_defaults(input):
+    """
+        if dict has multiple entries, look for identical key/value 
+        pairs and move them to DEFAULTS
+    """
+    defaults = {}
+    # get list of potential defaults
+    for name, params in input.items():
+        if not isinstance(params, dict): 
+            continue
+        for k,v in params.items():
+            if isinstance(v, dict): 
+                continue
+            if k not in defaults.keys():
+               defaults[k] = v
+    # disqualify defaults if not universal
+    for k, v in defaults.items():
+        for name, params in input.items():
+            if not isinstance(params, dict):
+                continue
+            value = params.get(k)
+            if v != value and k in defaults.keys():
+                defaults.pop(k)
+    if len(defaults.keys()) == 0:
+        return
+    # remove universal parameters from individual spec
+    for name, params in input.items():
+        if not isinstance(params, dict): 
+            continue
+        for k in params.keys():
+            if k in defaults.keys():
+                params.pop(k)
+    # add defaults to original data
+    if 'DEFAULTS' in input.keys():
+        input['DEFAULTS'].update(defaults)
+    else:
+        input['DEFAULTS'] = defaults
+
+
+def sort_yaml_data(data):
+    """
+        Sort YAML data before outputting
+    """
+    if not isinstance(data, dict):
+        return data
+    ordered = OrderedDict()
+    if 'name' in data.keys():
+        ordered['name'] = data.get('name')
+    for k in data.keys():
+        if k.startswith('z'):
+            ordered[k] = data.get(k)
+    # this is the desired order
+    for x in YAML_PREFERRED_ORDER:
+        if x in data.keys():
+            data_ = data.get(x)
+            ordered[x] = sort_yaml_data(data_)
+            # do further sorting
+            if x == 'device_classes':
+                # preferred ordering for device classes
+                for k, v in data_.items():
+                    ordered[x][k] = sort_yaml_data(v)
+    # catch anything we missed
+    for k in [x for x in data.keys() if x not in YAML_PREFERRED_ORDER]:
+        ordered[k] = sort_yaml_data(data.get(k))
+    return ordered
+

--- a/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
@@ -24,6 +24,7 @@ from ..resources.templates import SETUP_PY
 from ..helpers.WarningLoader import WarningLoader
 from ..helpers.Dumper import Dumper
 from ..helpers.Loader import Loader
+from ..helpers.utils import optimize_yaml
 
 
 class ZPLCommand(ZenScriptBase):
@@ -72,7 +73,10 @@ class ZPLCommand(ZenScriptBase):
                     dest="lint",
                     action="store_true",
                     help="check zenpack.yaml syntax for errors")
-
+        group.add_option("-o", "--optimize",
+                    dest="optimize",
+                    action="store_true",
+                    help="optimize zenpack.yaml format and DEFAULTS")
         group.add_option("-d", "--diagram",
                     dest="diagram",
                     action="store_true",
@@ -134,7 +138,7 @@ class ZPLCommand(ZenScriptBase):
             self.parser.print_help()
             self.parser.exit(1)
 
-        if self.options.lint or self.options.diagram:
+        if self.options.lint or self.options.diagram or self.options.optimize:
 
             self.parser.usage = "%prog [options] FILENAME"
             if len(self.args) != 1:
@@ -178,11 +182,22 @@ class ZPLCommand(ZenScriptBase):
         elif self.options.lint:
             self.lint(self.options.filename)
 
+        elif self.options.optimize:
+            self.optimize(self.options.filename)
+
         elif self.options.diagram:
             self.class_diagram('yuml', self.options.filename)
 
         elif self.options.paths:
             self.list_paths()
+
+    def optimize(self, filename):
+        '''return formatted YAML with DEFAULTS optimized'''
+        try:
+            new_yaml = optimize_yaml(filename)
+            print new_yaml
+        except Exception, e:
+            LOG.exception(e)
 
     def lint(self, filename):
         '''parse YAML file and check syntax'''
@@ -207,7 +222,6 @@ class ZPLCommand(ZenScriptBase):
 
     def create_zenpack_srcdir(self, zenpack_name):
         """Create a new ZenPack source directory."""
-        import shutil
         import errno
 
         if os.path.exists(zenpack_name):
@@ -281,10 +295,6 @@ class ZPLCommand(ZenScriptBase):
         print "  - creating file: {}".format(yaml_fname)
         with open(yaml_fname, 'w') as yaml_f:
             yaml_f.write("name: {}\n".format(zenpack_name))
-
-        # Copy zenpacklib.py (this file) into ZenPack module directory.
-        #print "  - copying: {} to {}".format(__file__, module_directory)
-        #shutil.copy2(__file__, module_directory)
 
     def py_to_yaml(self, zenpack_name):
         '''Create YAML based on existing ZenPack'''

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -1,6 +1,7 @@
 import os
 import math
 import re
+import time
 from zope.interface import classImplements
 from Products.Zuul.decorators import memoize
 from Products.Zuul.utils import ZuulMessageFactory as _t

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
@@ -82,6 +82,7 @@ class GraphPointSpec(Spec):
         # Allow color to be specified by color_index instead of directly. This is
         # useful when you want to keep the normal progression of colors, but need
         # to add some DONTDRAW graphpoints for calculations.
+        self.colorindex = colorindex
         if colorindex:
             try:
                 colorindex = int(colorindex) % len(GraphPoint.colors)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
@@ -68,8 +68,8 @@ class RRDDatapointSpec(Spec):
             self.aliases = aliases
         else:
             raise ValueError("aliases must be specified as a dict")
-
-        if shorthand:
+        self.shorthand = shorthand
+        if self.shorthand:
             if 'DERIVE' in shorthand.upper():
                 self.rrdtype = 'DERIVE'
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -196,7 +196,7 @@ class Spec(object):
     def specs_from_param(self, spec_type, param_name, param_dict, apply_defaults=True, leave_defaults=False, log=LOG):
         """Return a normalized dictionary of spec_type instances."""
         if param_dict is None:
-            param_dict = {}
+            param_dict = OrderedDict()
         elif not isinstance(param_dict, dict):
             raise TypeError(
                 "{!r} argument must be dict or None, not {!r}"
@@ -208,7 +208,10 @@ class Spec(object):
                 self.apply_data_defaults(param_dict, leave_defaults=leave_defaults)
 
         specs = OrderedDict()
-        for k, v in param_dict.iteritems():
+        keys = param_dict.keys()
+        keys.sort()
+        for k in keys:
+            v = param_dict.get(k)
             args = fix_kwargs(v)
             args['log'] = log
             specs[k] = spec_type(self, k, **(args))

--- a/ZenPacks/zenoss/ZenPackLib/lib/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/utils.py
@@ -14,6 +14,20 @@ FACET_BLACKLIST = (
 ### functions to determine conditional imports elsewhere
 
 
+def yaml_installed():
+    '''Return True if Impact is installed'''
+    try:
+        import yaml
+        import yaml.constructor
+        import yaml.doodads
+    except ImportError:
+        LOG.critical('PyYAML is required but not installed. Run "easy_install PyYAML" or "pip install PyYAML"')
+        pass
+    else:
+        return True
+    return False
+
+
 def impact_installed():
     '''Return True if Impact is installed'''
     try:

--- a/ZenPacks/zenoss/ZenPackLib/lib/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/utils.py
@@ -1,6 +1,6 @@
 from .helpers.ZenPackLibLog import ZenPackLibLog
-ZPLOG = ZenPackLibLog()
-LOG = ZPLOG.defaultlog
+from .functions import LOG
+
 
 FACET_BLACKLIST = (
     'dependencies',
@@ -12,18 +12,6 @@ FACET_BLACKLIST = (
 
 
 ### functions to determine conditional imports elsewhere
-
-def yaml_installed():
-    '''Return True if Impact is installed'''
-    try:
-        import yaml
-        import yaml.constructor
-    except ImportError:
-        LOG.critical('PyYAML is required but not installed. Run "easy_install PyYAML" or "pip install PyYAML"')
-        pass
-    else:
-        return True
-    return False
 
 
 def impact_installed():

--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
@@ -15,13 +15,27 @@ from Products.ZenUtils.ZenScriptBase import ZenScriptBase
 
 # change this to use other versions of zenpacklib
 from ZenPacks.zenoss.ZenPackLib import zenpacklib
-from ZenPacks.zenoss.ZenPackLib.lib.functions import str_to_severity
 
-def file_from_string(s):
-    with tempfile.NamedTemporaryFile() as f:
-        f.write(s.strip())
-        f.flush()
-        return f
+
+def str_to_severity(value):
+    '''
+    Return numeric severity given a string representation of severity.
+    '''
+    try:
+        severity = int(value)
+    except (TypeError, ValueError):
+        severity = {
+            'crit': 5, 'critical': 5,
+            'err': 4, 'error': 4,
+            'warn': 3, 'warning': 3,
+            'info': 2, 'information': 2, 'informational': 2,
+            'debug': 1, 'debugging': 1,
+            'clear': 0,
+            }.get(value.lower())
+    if severity is None:
+        raise ValueError("'%s' is not a valid value for severity." % value)
+    return severity
+
 
 class ZPLTestHarness(ZenScriptBase):
     '''Class containing methods to build out dummy objects representing YAML class instances'''

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/defaults.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/defaults.yaml
@@ -1,0 +1,44 @@
+name: ZenPacks.zenoss.ZenPackLib
+
+device_classes:
+  /Device:
+    templates:
+      TESTDEFAULTS:
+        description: you should see that DEFAULTS get set
+        datasources:
+          # THESE defaults arent working so set manually below remove when fixed
+          DEFAULTS:
+            type: Datapoint Aggregator
+            eventClass: /App/Zenoss
+            component: "${here/id}"
+            targetDataSource: ethernetcmascd_64
+            targetDataPoint: ifHCOutOctets
+            targetMethod: os.interfaces
+          agg_out_octets:
+            eventClass: /Cmd/Fail
+            datapoints:
+              aggifHCOutOctets:
+                operation: sum
+          agg_in_octets:
+            datapoints:
+              aggifHCInOctets:
+                operation: sum
+        thresholds:
+          DEFAULTS:
+            eventClass: /Perf
+            severity: crit
+            minval: -100
+            maxval: 100
+          TEST:
+            dsnames: [agg_out_octets_aggifHCOutOctets]
+        graphs:
+          DEFAULTS:
+            width: 1000
+            miny: 0
+            units: oct per sec
+          Aggregated Octets:
+            graphpoints:
+              RX:
+                dpName: agg_out_octets_aggifHCOutOctets
+              TX:
+                dpName: agg_in_octets_aggifHCInOctets

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/dump-test.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/dump-test.yaml
@@ -11,9 +11,6 @@ name: ZenPacks.zenoss.ZenPackLib
 classes:
   BasicDeviceComponent:
     base: [zenpacklib.Component]
-    properties:
-      something:
-        label: Something
 
 class_relationships:
 - Products.ZenModel.Device.Device 1:MC BasicDeviceComponent

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/test_dir_load/azure-1.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/test_dir_load/azure-1.yaml
@@ -1,0 +1,14 @@
+name: ZenPacks.zenoss.Microsoft.Azure
+zProperties:
+  DEFAULTS:
+    category: Microsoft Azure
+  zAzureEAAccessKey:
+    default: ''
+  zAzureEAEnrollmentNumber:
+    default: ''
+  zAzureEABillingCostThreshold:
+    type: multilinethreshold
+    default: '{}'
+  zAzureMonitoringIgnore:
+    default: ''
+

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/test_dir_load/azure-2.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/test_dir_load/azure-2.yaml
@@ -1,0 +1,466 @@
+class_relationships:
+- AzureSubscription(affinity_groups) 1:MC (subscription)AzureAffinityGroup
+- AzureSubscription(hosted_services) 1:MC (subscription)AzureHostedService
+- AzureHostedService(instances) 1:MC (hosted_service)AzureInstance
+- AzureInstance(disks) 1:MC (instance)AzureDisk
+- AzureSubscription(storage_services) 1:MC (subscription)AzureStorageService
+- AzureStorageService(queues) 1:MC (storage_service)AzureQueue
+- AzureStorageService(tables) 1:MC (storage_service)AzureTable
+- AzureStorageService(containers) 1:MC (storage_service)AzureContainer
+- AzureContainer(blobs) 1:MC (container)AzureBlob
+- AzureSubscription(web_spaces) 1:MC (subscription)AzureWebSpace
+- AzureWebSpace(sites) 1:MC (web_space)AzureSite
+- AzureSubscription(virtual_network_sites) 1:MC (subscription)AzureVirtualNetworkSite
+- AzureVirtualNetworkSite(subnets) 1:MC (virtual_network_site)AzureSubnet
+- AzureSubscription(locations) 1:MC (subscription)AzureLocation
+
+
+classes:
+  DEFAULTS:
+    base: [AzureComponent]
+
+  AzureComponent:
+    base: [zenpacklib.Component]
+
+  SubscriptionObject:
+    base: [AzureComponent]
+    properties:
+      getSubscription:
+        label: Subscription
+        grid_display: true
+        api_only: true
+        api_backendtype: method
+        type: entity
+        order: 1
+        content_width: 90
+
+  AzureServiceObject:
+    base: [AzureComponent]
+    properties:
+      service_status:
+        label: Service Status
+        grid_display: true
+        content_width: 90
+        order: 2
+
+  AzureStatusObject:
+    base: [AzureComponent]
+    properties:
+      status:
+        label: Status
+        api_only: true
+        api_backendtype: method
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        content_width: 60
+        order: 10
+
+  AzureSubscription:
+    base: [zenpacklib.Device]
+    label: Subscription
+    properties:
+      DEFAULTS:
+        grid_display: false
+      subscription_id:
+        label: Subscription ID
+      cert_file:
+        label: Cert File
+      service_status:
+        label: Service Status
+      max_core_count:
+        label: Max Core Count
+      max_storage_accounts:
+        label: Max Storage Accounts
+      max_hosted_services:
+        label: Max Hosted Services
+      max_virtual_network_sites:
+        label: Max Virtual Network Sites
+      max_local_network_sites:
+        label: Max Local Network Sites
+      max_dns_servers:
+        label: Max DNS Servers
+      current_core_count:
+        label: Current Core Count
+      current_hosted_services:
+        label: Current Hosted Services
+      current_storage_accounts:
+        label: Current Storage Accounts
+      model_time:
+        label: Model Time
+      first_seen:
+        label: First Seen
+        api_only: true
+        api_backendtype: method
+      last_change:
+        label: Last Change
+        api_only: true
+        api_backendtype: method
+    dynamicview_group: Subscription
+    dynamicview_relations:
+      impacts: [hosted_services, storage_services, web_spaces, virtual_network_sites, locations, affinity_groups]
+
+  AzureAffinityGroup:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Affinity Group
+    properties:
+      DEFAULTS:
+        grid_display: false
+      label:
+        label: Label
+      description:
+        label: Description
+        grid_display: true
+        order: 2
+      location:
+        label: Location
+        grid_display: true
+        order: 3
+      capabilities:
+        label: Capabilities
+        grid_display: true
+        order: 4
+      # prob should replace these 2 with relations
+      hosted_services:
+        label: Hosted Services
+      storage_services:
+        label: Storage Services
+    dynamicview_relations:
+      impacted_by: [subscription]
+    monitoring_templates: [AzureAffinityGroup]
+
+  AzureHostedService:
+    base: [SubscriptionObject,AzureServiceObject]
+    label: Hosted Service
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+      production_status:
+        label: Production Status
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        order: 7
+        content_width: 90
+      staging_status:
+        label: Staging Status
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        order: 8
+        content_width: 80
+      location:
+        label: Location
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 4
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 3
+      date_created:
+        label: Created
+        #grid_display: true
+        order: 5
+        content_width: 80
+      date_last_modified:
+        label: Last Modified
+        #grid_display: true
+        order: 6
+        content_width: 90
+    dynamicview_relations:
+      impacts: [instances]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureHostedService]
+
+  AzureStorageService:
+    base: [SubscriptionObject, AzureStatusObject, AzureServiceObject]
+    label: Storage Service
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+      location:
+        label: Location
+        grid_display: true
+        order: 4
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        content_width: 100
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        order: 3
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        content_width: 100
+    relationships:
+      DEFAULTS:
+        grid_display: false
+      tables: {
+      }
+      queues: {
+      }
+      containers: {
+      }
+    dynamicview_relations:
+      impacts: [containers, tables, queues]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureStorageService]
+
+  AzureWebSpace:
+    base: [SubscriptionObject, AzureStatusObject, AzureServiceObject]
+    label: Web Space
+    properties:
+      DEFAULTS:
+        grid_display: false
+      plan:
+        label: Plan
+      geo_location:
+        label: Geo Location
+      number_of_workers:
+        label: Workers
+      availability_state:
+        label: Availability State
+        order: 3
+        grid_display: true
+      compute_mode:
+        label: Compute Mode
+    relationships:
+      DEFAULTS:
+        grid_display: false
+      sites: {
+      }
+    dynamicview_relations:
+      impacts: [sites]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureWebSpace]
+
+  AzureVirtualNetworkSite:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Virtual Network Site
+    properties:
+      DEFAULTS:
+        grid_display: false
+      label:
+        label: Label
+        grid_display: true
+      vn_id:
+        label: VN ID
+        grid_display: true
+        order: 2
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 3
+      state:
+        label: State
+        grid_display: true
+        order: 4
+    dynamicview_relations:
+      impacts: [subnets]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureVirtualNetworkSite]
+
+  AzureLocation:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Location
+    dynamicview_relations:
+      impacted_by: [subscription]
+    monitoring_templates: [AzureLocation]
+
+  AzureInstance:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Instance
+    properties:
+      DEFAULTS:
+        grid_display: false
+      instance_status:
+        label: Instance Status
+        grid_display: true
+        order: 2
+      instance_size:
+        label: Instance Size
+      ip_address:
+        label: IP Address
+        grid_display: true
+        order: 3
+      power_state:
+        label: Power State
+        grid_display: true
+        order: 4
+      instance_error_code:
+        label: Instance Error Code
+      fqdn:
+        label: FQDN
+    dynamicview_relations:
+      impacted_by: [disks, hosted_service]
+    monitoring_templates: [AzureInstance]
+
+  AzureBlob:
+    label: Blob
+    base: [AzureStatusObject]
+    properties:
+      DEFAULTS:
+        grid_display: false
+      snapshot:
+        label: Snapshot
+      url:
+        label: URL
+      snapshot:
+        label: Snapshot
+      content_length:
+        label: Content Length
+        grid_display: true
+        order: 2
+      content_type:
+        label: Content Type
+        grid_display: true
+        order: 3
+      blob_type:
+        label: Blob Type
+        grid_display: true
+        order: 4
+      lease_status:
+        label: Lease Status
+        grid_display: true
+        order: 5
+      attached:
+        label: Attached Status
+        grid_display: false
+    dynamicview_relations:
+      impacted_by: [container]
+    monitoring_templates: [AzureBlob]
+
+  AzureContainer:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Container
+    properties:
+      DEFAULTS:
+        grid_display: true
+      url:
+        label: URL
+        order: 3
+      last_modified:
+        label: Last Modified
+        order: 2
+    dynamicview_relations:
+      impacts: [blobs]
+      impacted_by: [storage_service]
+    monitoring_templates: [AzureContainer]
+
+  AzureDisk:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Disk
+    properties:
+      DEFAULTS:
+        grid_display: false
+      affinity_group:
+        label: Affinity Group
+      has_operating_system:
+        label: Has Operating System
+      is_corrupted:
+        label: Is Corrupted
+      location:
+        label: Location
+        grid_display: true
+        order: 2
+      logical_disk_size_in_gb:
+        label: Logical Disk Size In GB
+        short_label: Size
+        grid_display: true
+        order: 4
+      label:
+        label: Label
+      media_link:
+        label: Media Link
+      os:
+        label: OS
+        grid_display: true
+        order: 3
+      source_image_name:
+        label: Source Image Name
+    dynamicview_relations:
+      impacts: [instance]
+    monitoring_templates: [AzureDisk]
+
+  AzureQueue:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Queue
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+    dynamicview_relations:
+      impacted_by: [subscription, storage_service]
+    monitoring_templates: [AzureQueue]
+
+  AzureSite:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Site
+    properties:
+      DEFAULTS:
+        grid_display: false
+      state:
+        label: State
+      server_farm:
+        label: Server Farm
+      owner:
+        label: Owner
+      availability_state:
+        label: Availability State
+        grid_display: true
+        order: 2
+      runtime_availability_state:
+        label: Runtime Availability
+        #grid_display: true
+        #order: 3
+      admin_enabled:
+        label: Admin Enabled
+        grid_display: true
+        order: 5
+      compute_mode:
+        label: Compute Mode
+      enabled:
+        label: Enabled
+      host_names:
+        label: Host Names
+        #grid_display: true
+        #order: 6
+        renderer: Zenoss.render.azure_URL
+      enabled_host_names:
+        label: Enabled Host Names
+      self_link:
+        label: Self Link
+      usage_state:
+        label: Usage State
+        grid_display: true
+        order: 4
+    dynamicview_relations:
+      impacted_by: [web_space]
+    monitoring_templates: [AzureSite]
+
+  AzureSubnet:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Subnet
+    properties:
+      DEFAULTS:
+        grid_display: true
+      address_prefix:
+        label: Address Prefix
+        order: 2
+    dynamicview_relations:
+      impacted_by: [virtual_network_site]
+    monitoring_templates: [AzureSubnet]
+
+  AzureTable:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Table
+    properties:
+      DEFAULTS:
+        grid_display: false    
+    dynamicview_relations:
+      impacted_by: [subscription, storage_service]
+    monitoring_templates: [AzureTable]
+

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/test_dir_load/azure-3.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/test_dir_load/azure-3.yaml
@@ -1,0 +1,194 @@
+device_classes:
+  /Azure:
+    remove: true
+    zProperties:
+      zPythonClass: ZenPacks.zenoss.Microsoft.Azure.AzureSubscription
+      zCollectorPlugins:
+        - AzureCollector
+      zDeviceTemplates:
+        - AzureSubscription
+    templates:
+      AzureAffinityGroup:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureBlob:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 1800
+      AzureContainer:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureDisk:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureHostedService:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureInstance:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureSite:
+        targetPythonClass: ZenPacks.zenoss.Microsoft.Azure.AzureSite
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+            datapoints:
+              bytes_received:
+                aliases: {bytes_received: null}
+              bytes_sent:
+                aliases: {bytes_sent: null}
+              cpu_time:
+                aliases: {cpu_time: null}
+              filesystem_storage:
+                aliases: {filesystem_storage: null}
+              local_bytes_read:
+                aliases: {local_bytes_read: null}
+              local_bytes_written:
+                aliases: {local_bytes_written: null}
+              memory_usage:
+                aliases: {memory_usage: null}
+        graphs:
+          Bytes:
+            units: Bytes
+            graphpoints:
+              bytes_received:
+                dpName: AzureDataSource_bytes_received
+                legend: Received
+              bytes_sent:
+                dpName: AzureDataSource_bytes_sent
+                legend: Sent
+              local_bytes_read:
+                dpName: AzureDataSource_local_bytes_read
+                legend: Local bytes read
+              local_bytes_written:
+                dpName: AzureDataSource_local_bytes_written
+                legend: Local bytes written
+          CPU time:
+            units: Miliseconds
+            graphpoints:
+              cpu_time:
+                dpName: AzureDataSource_cpu_time
+                legend: CPU time
+          Filesystem:
+            units: Bytes
+            graphpoints:
+              filesystem_storage:
+                dpName: AzureDataSource_filesystem_storage
+                legend: Storage
+          Memory:
+            units: Bytes
+            graphpoints:
+              memory_usage:
+                dpName: AzureDataSource_memory_usage
+                legend: Usage
+      AzureStorageService:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+            datapoints:
+              blobs_capacity:
+                aliases: {blobs_capacity: null}
+              blobs_container_count:
+                aliases: {blobs_container_count: null}
+              blobs_object_count:
+                aliases: {blobs_object_count: null}
+        graphs:
+          Blobs:
+            units: Count
+            miny: 0
+            maxy: 0
+            graphpoints:
+              blobs_container_count:
+                dpName: AzureDataSource_blobs_container_count
+                legend: Container count
+              blobs_object_count:
+                dpName: AzureDataSource_blobs_object_count
+                legend: Object count
+          Blobs capacity:
+            units: Bytes
+            graphpoints:
+              blobs_capacity:
+                dpName: AzureDataSource_blobs_capacity
+                legend: Capacity
+      AzureSubnet:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureSubscription:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            cycletime: 300
+            datapoints:
+              current_core_count: {}
+              current_hosted_services: {}
+              current_storage_accounts: {}
+              max_core_count: {}
+              max_hosted_services: {}
+              max_storage_accounts: {}
+        graphs:
+          Cores:
+            units: Cores
+            miny: 0
+            graphpoints:
+              current_core_count:
+                dpName: AzureDataSource_current_core_count
+                legend: Current core count
+              max_core_count:
+                dpName: AzureDataSource_max_core_count
+                legend: Max core count
+          Hosted services:
+            units: Hosted services
+            miny: 0
+            graphpoints:
+              current_hosted_services:
+                dpName: AzureDataSource_current_hosted_services
+                legend: Current hosted services
+              max_hosted_services:
+                dpName: AzureDataSource_max_hosted_services
+                legend: Max hosted services
+          Storage accounts:
+            units: storage accounts
+            miny: 0
+            graphpoints:
+              current_storage_accounts:
+                dpName: AzureDataSource_current_storage_accounts
+                legend: Current storage accounts
+              max_storage_accounts:
+                dpName: AzureDataSource_max_storage_accounts
+                legend: Max storage accounts
+      AzureVirtualNetworkSite:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureWebSpace:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-27049-extraparams.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/zen-27049-extraparams.yaml
@@ -1,0 +1,19 @@
+name: ZenPacks.community.TestDEFAULSonDatasource
+
+device_classes:
+  /Device:
+    templates:
+      TESTTEMPLATE:
+        description: Testing that Duration threshold accepts integer values
+        datasources:
+          currentReading:
+            type: SNMP
+            datapoints:
+              currentReading: {}
+            oid: .1.3.6.1.4.1.232.6.2.6.8.1.4
+        thresholds:
+          DurationThreshold:
+            type: DurationThreshold
+            dsnames: [currentReading_currentReading]
+            violationPercentage: 10
+            timePeriod: 2 days

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_load_dir.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_load_dir.py
@@ -1,0 +1,753 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+""" Multi-YAML import load
+
+Tests YAML loading from multiple files
+
+"""
+# stdlib Imports
+import os
+import site
+import tempfile
+import traceback
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+# zenpacklib Imports
+from ZenPacks.zenoss.ZenPackLib import zenpacklib
+import yaml
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Dumper import Dumper
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Loader import Loader
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.utils import compare_zenpackspecs
+
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+
+YAML_WHOLE = """
+name: ZenPacks.zenoss.Microsoft.Azure
+zProperties:
+  DEFAULTS:
+    category: Microsoft Azure
+  zAzureEAAccessKey:
+    default: ''
+  zAzureEAEnrollmentNumber:
+    default: ''
+  zAzureEABillingCostThreshold:
+    type: multilinethreshold
+    default: '{}'
+  zAzureMonitoringIgnore:
+    default: ''
+
+
+class_relationships:
+- AzureSubscription(affinity_groups) 1:MC (subscription)AzureAffinityGroup
+- AzureSubscription(hosted_services) 1:MC (subscription)AzureHostedService
+- AzureHostedService(instances) 1:MC (hosted_service)AzureInstance
+- AzureInstance(disks) 1:MC (instance)AzureDisk
+- AzureSubscription(storage_services) 1:MC (subscription)AzureStorageService
+- AzureStorageService(queues) 1:MC (storage_service)AzureQueue
+- AzureStorageService(tables) 1:MC (storage_service)AzureTable
+- AzureStorageService(containers) 1:MC (storage_service)AzureContainer
+- AzureContainer(blobs) 1:MC (container)AzureBlob
+- AzureSubscription(web_spaces) 1:MC (subscription)AzureWebSpace
+- AzureWebSpace(sites) 1:MC (web_space)AzureSite
+- AzureSubscription(virtual_network_sites) 1:MC (subscription)AzureVirtualNetworkSite
+- AzureVirtualNetworkSite(subnets) 1:MC (virtual_network_site)AzureSubnet
+- AzureSubscription(locations) 1:MC (subscription)AzureLocation
+
+
+classes:
+  DEFAULTS:
+    base: [AzureComponent]
+
+  AzureComponent:
+    base: [zenpacklib.Component]
+
+  SubscriptionObject:
+    base: [AzureComponent]
+    properties:
+      getSubscription:
+        label: Subscription
+        grid_display: true
+        api_only: true
+        api_backendtype: method
+        type: entity
+        order: 1
+        content_width: 90
+
+  AzureServiceObject:
+    base: [AzureComponent]
+    properties:
+      service_status:
+        label: Service Status
+        grid_display: true
+        content_width: 90
+        order: 2
+
+  AzureStatusObject:
+    base: [AzureComponent]
+    properties:
+      status:
+        label: Status
+        api_only: true
+        api_backendtype: method
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        content_width: 60
+        order: 10
+
+  AzureSubscription:
+    base: [zenpacklib.Device]
+    label: Subscription
+    properties:
+      DEFAULTS:
+        grid_display: false
+      subscription_id:
+        label: Subscription ID
+      cert_file:
+        label: Cert File
+      service_status:
+        label: Service Status
+      max_core_count:
+        label: Max Core Count
+      max_storage_accounts:
+        label: Max Storage Accounts
+      max_hosted_services:
+        label: Max Hosted Services
+      max_virtual_network_sites:
+        label: Max Virtual Network Sites
+      max_local_network_sites:
+        label: Max Local Network Sites
+      max_dns_servers:
+        label: Max DNS Servers
+      current_core_count:
+        label: Current Core Count
+      current_hosted_services:
+        label: Current Hosted Services
+      current_storage_accounts:
+        label: Current Storage Accounts
+      model_time:
+        label: Model Time
+      first_seen:
+        label: First Seen
+        api_only: true
+        api_backendtype: method
+      last_change:
+        label: Last Change
+        api_only: true
+        api_backendtype: method
+    dynamicview_group: Subscription
+    dynamicview_relations:
+      impacts: [hosted_services, storage_services, web_spaces, virtual_network_sites, locations, affinity_groups]
+
+  AzureAffinityGroup:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Affinity Group
+    properties:
+      DEFAULTS:
+        grid_display: false
+      label:
+        label: Label
+      description:
+        label: Description
+        grid_display: true
+        order: 2
+      location:
+        label: Location
+        grid_display: true
+        order: 3
+      capabilities:
+        label: Capabilities
+        grid_display: true
+        order: 4
+      # prob should replace these 2 with relations
+      hosted_services:
+        label: Hosted Services
+      storage_services:
+        label: Storage Services
+    dynamicview_relations:
+      impacted_by: [subscription]
+    monitoring_templates: [AzureAffinityGroup]
+
+  AzureHostedService:
+    base: [SubscriptionObject,AzureServiceObject]
+    label: Hosted Service
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+      production_status:
+        label: Production Status
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        order: 7
+        content_width: 90
+      staging_status:
+        label: Staging Status
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        order: 8
+        content_width: 80
+      location:
+        label: Location
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 4
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 3
+      date_created:
+        label: Created
+        #grid_display: true
+        order: 5
+        content_width: 80
+      date_last_modified:
+        label: Last Modified
+        #grid_display: true
+        order: 6
+        content_width: 90
+    dynamicview_relations:
+      impacts: [instances]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureHostedService]
+
+  AzureStorageService:
+    base: [SubscriptionObject, AzureStatusObject, AzureServiceObject]
+    label: Storage Service
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+      location:
+        label: Location
+        grid_display: true
+        order: 4
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        content_width: 100
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        order: 3
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        content_width: 100
+    relationships:
+      DEFAULTS:
+        grid_display: false
+      tables: {
+      }
+      queues: {
+      }
+      containers: {
+      }
+    dynamicview_relations:
+      impacts: [containers, tables, queues]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureStorageService]
+
+  AzureWebSpace:
+    base: [SubscriptionObject, AzureStatusObject, AzureServiceObject]
+    label: Web Space
+    properties:
+      DEFAULTS:
+        grid_display: false
+      plan:
+        label: Plan
+      geo_location:
+        label: Geo Location
+      number_of_workers:
+        label: Workers
+      availability_state:
+        label: Availability State
+        order: 3
+        grid_display: true
+      compute_mode:
+        label: Compute Mode
+    relationships:
+      DEFAULTS:
+        grid_display: false
+      sites: {
+      }
+    dynamicview_relations:
+      impacts: [sites]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureWebSpace]
+
+  AzureVirtualNetworkSite:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Virtual Network Site
+    properties:
+      DEFAULTS:
+        grid_display: false
+      label:
+        label: Label
+        grid_display: true
+      vn_id:
+        label: VN ID
+        grid_display: true
+        order: 2
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 3
+      state:
+        label: State
+        grid_display: true
+        order: 4
+    dynamicview_relations:
+      impacts: [subnets]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureVirtualNetworkSite]
+
+  AzureLocation:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Location
+    dynamicview_relations:
+      impacted_by: [subscription]
+    monitoring_templates: [AzureLocation]
+
+  AzureInstance:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Instance
+    properties:
+      DEFAULTS:
+        grid_display: false
+      instance_status:
+        label: Instance Status
+        grid_display: true
+        order: 2
+      instance_size:
+        label: Instance Size
+      ip_address:
+        label: IP Address
+        grid_display: true
+        order: 3
+      power_state:
+        label: Power State
+        grid_display: true
+        order: 4
+      instance_error_code:
+        label: Instance Error Code
+      fqdn:
+        label: FQDN
+    dynamicview_relations:
+      impacted_by: [disks, hosted_service]
+    monitoring_templates: [AzureInstance]
+
+  AzureBlob:
+    label: Blob
+    base: [AzureStatusObject]
+    properties:
+      DEFAULTS:
+        grid_display: false
+      snapshot:
+        label: Snapshot
+      url:
+        label: URL
+      snapshot:
+        label: Snapshot
+      content_length:
+        label: Content Length
+        grid_display: true
+        order: 2
+      content_type:
+        label: Content Type
+        grid_display: true
+        order: 3
+      blob_type:
+        label: Blob Type
+        grid_display: true
+        order: 4
+      lease_status:
+        label: Lease Status
+        grid_display: true
+        order: 5
+      attached:
+        label: Attached Status
+        grid_display: false
+    dynamicview_relations:
+      impacted_by: [container]
+    monitoring_templates: [AzureBlob]
+
+  AzureContainer:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Container
+    properties:
+      DEFAULTS:
+        grid_display: true
+      url:
+        label: URL
+        order: 3
+      last_modified:
+        label: Last Modified
+        order: 2
+    dynamicview_relations:
+      impacts: [blobs]
+      impacted_by: [storage_service]
+    monitoring_templates: [AzureContainer]
+
+  AzureDisk:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Disk
+    properties:
+      DEFAULTS:
+        grid_display: false
+      affinity_group:
+        label: Affinity Group
+      has_operating_system:
+        label: Has Operating System
+      is_corrupted:
+        label: Is Corrupted
+      location:
+        label: Location
+        grid_display: true
+        order: 2
+      logical_disk_size_in_gb:
+        label: Logical Disk Size In GB
+        short_label: Size
+        grid_display: true
+        order: 4
+      label:
+        label: Label
+      media_link:
+        label: Media Link
+      os:
+        label: OS
+        grid_display: true
+        order: 3
+      source_image_name:
+        label: Source Image Name
+    dynamicview_relations:
+      impacts: [instance]
+    monitoring_templates: [AzureDisk]
+
+  AzureQueue:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Queue
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+    dynamicview_relations:
+      impacted_by: [subscription, storage_service]
+    monitoring_templates: [AzureQueue]
+
+  AzureSite:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Site
+    properties:
+      DEFAULTS:
+        grid_display: false
+      state:
+        label: State
+      server_farm:
+        label: Server Farm
+      owner:
+        label: Owner
+      availability_state:
+        label: Availability State
+        grid_display: true
+        order: 2
+      runtime_availability_state:
+        label: Runtime Availability
+        #grid_display: true
+        #order: 3
+      admin_enabled:
+        label: Admin Enabled
+        grid_display: true
+        order: 5
+      compute_mode:
+        label: Compute Mode
+      enabled:
+        label: Enabled
+      host_names:
+        label: Host Names
+        #grid_display: true
+        #order: 6
+        renderer: Zenoss.render.azure_URL
+      enabled_host_names:
+        label: Enabled Host Names
+      self_link:
+        label: Self Link
+      usage_state:
+        label: Usage State
+        grid_display: true
+        order: 4
+    dynamicview_relations:
+      impacted_by: [web_space]
+    monitoring_templates: [AzureSite]
+
+  AzureSubnet:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Subnet
+    properties:
+      DEFAULTS:
+        grid_display: true
+      address_prefix:
+        label: Address Prefix
+        order: 2
+    dynamicview_relations:
+      impacted_by: [virtual_network_site]
+    monitoring_templates: [AzureSubnet]
+
+  AzureTable:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Table
+    properties:
+      DEFAULTS:
+        grid_display: false    
+    dynamicview_relations:
+      impacted_by: [subscription, storage_service]
+    monitoring_templates: [AzureTable]
+
+
+device_classes:
+  /Azure:
+    remove: true
+    zProperties:
+      zPythonClass: ZenPacks.zenoss.Microsoft.Azure.AzureSubscription
+      zCollectorPlugins:
+        - AzureCollector
+      zDeviceTemplates:
+        - AzureSubscription
+    templates:
+      AzureAffinityGroup:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureBlob:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 1800
+      AzureContainer:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureDisk:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureHostedService:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureInstance:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureSite:
+        targetPythonClass: ZenPacks.zenoss.Microsoft.Azure.AzureSite
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+            datapoints:
+              bytes_received:
+                aliases: {bytes_received: null}
+              bytes_sent:
+                aliases: {bytes_sent: null}
+              cpu_time:
+                aliases: {cpu_time: null}
+              filesystem_storage:
+                aliases: {filesystem_storage: null}
+              local_bytes_read:
+                aliases: {local_bytes_read: null}
+              local_bytes_written:
+                aliases: {local_bytes_written: null}
+              memory_usage:
+                aliases: {memory_usage: null}
+        graphs:
+          Bytes:
+            units: Bytes
+            graphpoints:
+              bytes_received:
+                dpName: AzureDataSource_bytes_received
+                legend: Received
+              bytes_sent:
+                dpName: AzureDataSource_bytes_sent
+                legend: Sent
+              local_bytes_read:
+                dpName: AzureDataSource_local_bytes_read
+                legend: Local bytes read
+              local_bytes_written:
+                dpName: AzureDataSource_local_bytes_written
+                legend: Local bytes written
+          CPU time:
+            units: Miliseconds
+            graphpoints:
+              cpu_time:
+                dpName: AzureDataSource_cpu_time
+                legend: CPU time
+          Filesystem:
+            units: Bytes
+            graphpoints:
+              filesystem_storage:
+                dpName: AzureDataSource_filesystem_storage
+                legend: Storage
+          Memory:
+            units: Bytes
+            graphpoints:
+              memory_usage:
+                dpName: AzureDataSource_memory_usage
+                legend: Usage
+      AzureStorageService:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+            datapoints:
+              blobs_capacity:
+                aliases: {blobs_capacity: null}
+              blobs_container_count:
+                aliases: {blobs_container_count: null}
+              blobs_object_count:
+                aliases: {blobs_object_count: null}
+        graphs:
+          Blobs:
+            units: Count
+            miny: 0
+            maxy: 0
+            graphpoints:
+              blobs_container_count:
+                dpName: AzureDataSource_blobs_container_count
+                legend: Container count
+              blobs_object_count:
+                dpName: AzureDataSource_blobs_object_count
+                legend: Object count
+          Blobs capacity:
+            units: Bytes
+            graphpoints:
+              blobs_capacity:
+                dpName: AzureDataSource_blobs_capacity
+                legend: Capacity
+      AzureSubnet:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureSubscription:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            cycletime: 300
+            datapoints:
+              current_core_count: {}
+              current_hosted_services: {}
+              current_storage_accounts: {}
+              max_core_count: {}
+              max_hosted_services: {}
+              max_storage_accounts: {}
+        graphs:
+          Cores:
+            units: Cores
+            miny: 0
+            graphpoints:
+              current_core_count:
+                dpName: AzureDataSource_current_core_count
+                legend: Current core count
+              max_core_count:
+                dpName: AzureDataSource_max_core_count
+                legend: Max core count
+          Hosted services:
+            units: Hosted services
+            miny: 0
+            graphpoints:
+              current_hosted_services:
+                dpName: AzureDataSource_current_hosted_services
+                legend: Current hosted services
+              max_hosted_services:
+                dpName: AzureDataSource_max_hosted_services
+                legend: Max hosted services
+          Storage accounts:
+            units: storage accounts
+            miny: 0
+            graphpoints:
+              current_storage_accounts:
+                dpName: AzureDataSource_current_storage_accounts
+                legend: Current storage accounts
+              max_storage_accounts:
+                dpName: AzureDataSource_max_storage_accounts
+                legend: Max storage accounts
+      AzureVirtualNetworkSite:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureWebSpace:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+
+"""
+
+
+
+class TestDirectoryLoad(BaseTestCase):
+    """Test loading from directory"""
+
+
+    def test_dir_load(self):
+        ''''''
+        # reference yaml (all in one
+        cfg_whole = zenpacklib.load_yaml(YAML_WHOLE)
+
+        # reference yaml split across multiple files
+        fdir = '%s/data/yaml/test_dir_load' % os.path.dirname(__file__)
+        cfg_dir = zenpacklib.load_yaml(fdir)
+
+        # dump both back to YAML
+        whole_yaml = yaml.dump(cfg_whole.specparams, Dumper=Dumper)
+        dir_yaml = yaml.dump(cfg_dir.specparams, Dumper=Dumper)
+
+        compare_equals = compare_zenpackspecs(whole_yaml, dir_yaml)
+
+        self.assertTrue(compare_equals, 
+                        'YAML Multiple file test failed')
+
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestDirectoryLoad))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_load_yaml_multi.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_load_yaml_multi.py
@@ -1,0 +1,1433 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+""" Multi-YAML import load
+
+Tests YAML loading from multiple files
+
+"""
+# stdlib Imports
+import os
+import site
+import tempfile
+import traceback
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+# zenpacklib Imports
+from ZenPacks.zenoss.ZenPackLib import zenpacklib
+import yaml
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Dumper import Dumper
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Loader import Loader
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.utils import compare_zenpackspecs
+
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+
+YAML_WHOLE = """
+name: ZenPacks.zenoss.Microsoft.Azure
+zProperties:
+  DEFAULTS:
+    category: Microsoft Azure
+  zAzureEAAccessKey:
+    default: ''
+  zAzureEAEnrollmentNumber:
+    default: ''
+  zAzureEABillingCostThreshold:
+    type: multilinethreshold
+    default: '{}'
+  zAzureMonitoringIgnore:
+    default: ''
+
+
+class_relationships:
+- AzureSubscription(affinity_groups) 1:MC (subscription)AzureAffinityGroup
+- AzureSubscription(hosted_services) 1:MC (subscription)AzureHostedService
+- AzureHostedService(instances) 1:MC (hosted_service)AzureInstance
+- AzureInstance(disks) 1:MC (instance)AzureDisk
+- AzureSubscription(storage_services) 1:MC (subscription)AzureStorageService
+- AzureStorageService(queues) 1:MC (storage_service)AzureQueue
+- AzureStorageService(tables) 1:MC (storage_service)AzureTable
+- AzureStorageService(containers) 1:MC (storage_service)AzureContainer
+- AzureContainer(blobs) 1:MC (container)AzureBlob
+- AzureSubscription(web_spaces) 1:MC (subscription)AzureWebSpace
+- AzureWebSpace(sites) 1:MC (web_space)AzureSite
+- AzureSubscription(virtual_network_sites) 1:MC (subscription)AzureVirtualNetworkSite
+- AzureVirtualNetworkSite(subnets) 1:MC (virtual_network_site)AzureSubnet
+- AzureSubscription(locations) 1:MC (subscription)AzureLocation
+
+
+classes:
+  DEFAULTS:
+    base: [AzureComponent]
+
+  AzureComponent:
+    base: [zenpacklib.Component]
+
+  SubscriptionObject:
+    base: [AzureComponent]
+    properties:
+      getSubscription:
+        label: Subscription
+        grid_display: true
+        api_only: true
+        api_backendtype: method
+        type: entity
+        order: 1
+        content_width: 90
+
+  AzureServiceObject:
+    base: [AzureComponent]
+    properties:
+      service_status:
+        label: Service Status
+        grid_display: true
+        content_width: 90
+        order: 2
+
+  AzureStatusObject:
+    base: [AzureComponent]
+    properties:
+      status:
+        label: Status
+        api_only: true
+        api_backendtype: method
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        content_width: 60
+        order: 10
+
+  AzureSubscription:
+    base: [zenpacklib.Device]
+    label: Subscription
+    properties:
+      DEFAULTS:
+        grid_display: false
+      subscription_id:
+        label: Subscription ID
+      cert_file:
+        label: Cert File
+      service_status:
+        label: Service Status
+      max_core_count:
+        label: Max Core Count
+      max_storage_accounts:
+        label: Max Storage Accounts
+      max_hosted_services:
+        label: Max Hosted Services
+      max_virtual_network_sites:
+        label: Max Virtual Network Sites
+      max_local_network_sites:
+        label: Max Local Network Sites
+      max_dns_servers:
+        label: Max DNS Servers
+      current_core_count:
+        label: Current Core Count
+      current_hosted_services:
+        label: Current Hosted Services
+      current_storage_accounts:
+        label: Current Storage Accounts
+      model_time:
+        label: Model Time
+      first_seen:
+        label: First Seen
+        api_only: true
+        api_backendtype: method
+      last_change:
+        label: Last Change
+        api_only: true
+        api_backendtype: method
+    dynamicview_group: Subscription
+    dynamicview_relations:
+      impacts: [hosted_services, storage_services, web_spaces, virtual_network_sites, locations, affinity_groups]
+
+  AzureAffinityGroup:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Affinity Group
+    properties:
+      DEFAULTS:
+        grid_display: false
+      label:
+        label: Label
+      description:
+        label: Description
+        grid_display: true
+        order: 2
+      location:
+        label: Location
+        grid_display: true
+        order: 3
+      capabilities:
+        label: Capabilities
+        grid_display: true
+        order: 4
+      # prob should replace these 2 with relations
+      hosted_services:
+        label: Hosted Services
+      storage_services:
+        label: Storage Services
+    dynamicview_relations:
+      impacted_by: [subscription]
+    monitoring_templates: [AzureAffinityGroup]
+
+  AzureHostedService:
+    base: [SubscriptionObject,AzureServiceObject]
+    label: Hosted Service
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+      production_status:
+        label: Production Status
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        order: 7
+        content_width: 90
+      staging_status:
+        label: Staging Status
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        order: 8
+        content_width: 80
+      location:
+        label: Location
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 4
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 3
+      date_created:
+        label: Created
+        #grid_display: true
+        order: 5
+        content_width: 80
+      date_last_modified:
+        label: Last Modified
+        #grid_display: true
+        order: 6
+        content_width: 90
+    dynamicview_relations:
+      impacts: [instances]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureHostedService]
+
+  AzureStorageService:
+    base: [SubscriptionObject, AzureStatusObject, AzureServiceObject]
+    label: Storage Service
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+      location:
+        label: Location
+        grid_display: true
+        order: 4
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        content_width: 100
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        order: 3
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        content_width: 100
+    relationships:
+      DEFAULTS:
+        grid_display: false
+      tables: {
+      }
+      queues: {
+      }
+      containers: {
+      }
+    dynamicview_relations:
+      impacts: [containers, tables, queues]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureStorageService]
+
+  AzureWebSpace:
+    base: [SubscriptionObject, AzureStatusObject, AzureServiceObject]
+    label: Web Space
+    properties:
+      DEFAULTS:
+        grid_display: false
+      plan:
+        label: Plan
+      geo_location:
+        label: Geo Location
+      number_of_workers:
+        label: Workers
+      availability_state:
+        label: Availability State
+        order: 3
+        grid_display: true
+      compute_mode:
+        label: Compute Mode
+    relationships:
+      DEFAULTS:
+        grid_display: false
+      sites: {
+      }
+    dynamicview_relations:
+      impacts: [sites]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureWebSpace]
+
+  AzureVirtualNetworkSite:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Virtual Network Site
+    properties:
+      DEFAULTS:
+        grid_display: false
+      label:
+        label: Label
+        grid_display: true
+      vn_id:
+        label: VN ID
+        grid_display: true
+        order: 2
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 3
+      state:
+        label: State
+        grid_display: true
+        order: 4
+    dynamicview_relations:
+      impacts: [subnets]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureVirtualNetworkSite]
+
+  AzureLocation:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Location
+    dynamicview_relations:
+      impacted_by: [subscription]
+    monitoring_templates: [AzureLocation]
+
+  AzureInstance:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Instance
+    properties:
+      DEFAULTS:
+        grid_display: false
+      instance_status:
+        label: Instance Status
+        grid_display: true
+        order: 2
+      instance_size:
+        label: Instance Size
+      ip_address:
+        label: IP Address
+        grid_display: true
+        order: 3
+      power_state:
+        label: Power State
+        grid_display: true
+        order: 4
+      instance_error_code:
+        label: Instance Error Code
+      fqdn:
+        label: FQDN
+    dynamicview_relations:
+      impacted_by: [disks, hosted_service]
+    monitoring_templates: [AzureInstance]
+
+  AzureBlob:
+    label: Blob
+    base: [AzureStatusObject]
+    properties:
+      DEFAULTS:
+        grid_display: false
+      snapshot:
+        label: Snapshot
+      url:
+        label: URL
+      snapshot:
+        label: Snapshot
+      content_length:
+        label: Content Length
+        grid_display: true
+        order: 2
+      content_type:
+        label: Content Type
+        grid_display: true
+        order: 3
+      blob_type:
+        label: Blob Type
+        grid_display: true
+        order: 4
+      lease_status:
+        label: Lease Status
+        grid_display: true
+        order: 5
+      attached:
+        label: Attached Status
+        grid_display: false
+    dynamicview_relations:
+      impacted_by: [container]
+    monitoring_templates: [AzureBlob]
+
+  AzureContainer:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Container
+    properties:
+      DEFAULTS:
+        grid_display: true
+      url:
+        label: URL
+        order: 3
+      last_modified:
+        label: Last Modified
+        order: 2
+    dynamicview_relations:
+      impacts: [blobs]
+      impacted_by: [storage_service]
+    monitoring_templates: [AzureContainer]
+
+  AzureDisk:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Disk
+    properties:
+      DEFAULTS:
+        grid_display: false
+      affinity_group:
+        label: Affinity Group
+      has_operating_system:
+        label: Has Operating System
+      is_corrupted:
+        label: Is Corrupted
+      location:
+        label: Location
+        grid_display: true
+        order: 2
+      logical_disk_size_in_gb:
+        label: Logical Disk Size In GB
+        short_label: Size
+        grid_display: true
+        order: 4
+      label:
+        label: Label
+      media_link:
+        label: Media Link
+      os:
+        label: OS
+        grid_display: true
+        order: 3
+      source_image_name:
+        label: Source Image Name
+    dynamicview_relations:
+      impacts: [instance]
+    monitoring_templates: [AzureDisk]
+
+  AzureQueue:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Queue
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+    dynamicview_relations:
+      impacted_by: [subscription, storage_service]
+    monitoring_templates: [AzureQueue]
+
+  AzureSite:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Site
+    properties:
+      DEFAULTS:
+        grid_display: false
+      state:
+        label: State
+      server_farm:
+        label: Server Farm
+      owner:
+        label: Owner
+      availability_state:
+        label: Availability State
+        grid_display: true
+        order: 2
+      runtime_availability_state:
+        label: Runtime Availability
+        #grid_display: true
+        #order: 3
+      admin_enabled:
+        label: Admin Enabled
+        grid_display: true
+        order: 5
+      compute_mode:
+        label: Compute Mode
+      enabled:
+        label: Enabled
+      host_names:
+        label: Host Names
+        #grid_display: true
+        #order: 6
+        renderer: Zenoss.render.azure_URL
+      enabled_host_names:
+        label: Enabled Host Names
+      self_link:
+        label: Self Link
+      usage_state:
+        label: Usage State
+        grid_display: true
+        order: 4
+    dynamicview_relations:
+      impacted_by: [web_space]
+    monitoring_templates: [AzureSite]
+
+  AzureSubnet:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Subnet
+    properties:
+      DEFAULTS:
+        grid_display: true
+      address_prefix:
+        label: Address Prefix
+        order: 2
+    dynamicview_relations:
+      impacted_by: [virtual_network_site]
+    monitoring_templates: [AzureSubnet]
+
+  AzureTable:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Table
+    properties:
+      DEFAULTS:
+        grid_display: false    
+    dynamicview_relations:
+      impacted_by: [subscription, storage_service]
+    monitoring_templates: [AzureTable]
+
+
+device_classes:
+  /Azure:
+    remove: true
+    zProperties:
+      zPythonClass: ZenPacks.zenoss.Microsoft.Azure.AzureSubscription
+      zCollectorPlugins:
+        - AzureCollector
+      zDeviceTemplates:
+        - AzureSubscription
+    templates:
+      AzureAffinityGroup:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureBlob:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 1800
+      AzureContainer:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureDisk:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureHostedService:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureInstance:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureSite:
+        targetPythonClass: ZenPacks.zenoss.Microsoft.Azure.AzureSite
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+            datapoints:
+              bytes_received:
+                aliases: {bytes_received: null}
+              bytes_sent:
+                aliases: {bytes_sent: null}
+              cpu_time:
+                aliases: {cpu_time: null}
+              filesystem_storage:
+                aliases: {filesystem_storage: null}
+              local_bytes_read:
+                aliases: {local_bytes_read: null}
+              local_bytes_written:
+                aliases: {local_bytes_written: null}
+              memory_usage:
+                aliases: {memory_usage: null}
+        graphs:
+          Bytes:
+            units: Bytes
+            graphpoints:
+              bytes_received:
+                dpName: AzureDataSource_bytes_received
+                legend: Received
+              bytes_sent:
+                dpName: AzureDataSource_bytes_sent
+                legend: Sent
+              local_bytes_read:
+                dpName: AzureDataSource_local_bytes_read
+                legend: Local bytes read
+              local_bytes_written:
+                dpName: AzureDataSource_local_bytes_written
+                legend: Local bytes written
+          CPU time:
+            units: Miliseconds
+            graphpoints:
+              cpu_time:
+                dpName: AzureDataSource_cpu_time
+                legend: CPU time
+          Filesystem:
+            units: Bytes
+            graphpoints:
+              filesystem_storage:
+                dpName: AzureDataSource_filesystem_storage
+                legend: Storage
+          Memory:
+            units: Bytes
+            graphpoints:
+              memory_usage:
+                dpName: AzureDataSource_memory_usage
+                legend: Usage
+      AzureStorageService:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+            datapoints:
+              blobs_capacity:
+                aliases: {blobs_capacity: null}
+              blobs_container_count:
+                aliases: {blobs_container_count: null}
+              blobs_object_count:
+                aliases: {blobs_object_count: null}
+        graphs:
+          Blobs:
+            units: Count
+            miny: 0
+            maxy: 0
+            graphpoints:
+              blobs_container_count:
+                dpName: AzureDataSource_blobs_container_count
+                legend: Container count
+              blobs_object_count:
+                dpName: AzureDataSource_blobs_object_count
+                legend: Object count
+          Blobs capacity:
+            units: Bytes
+            graphpoints:
+              blobs_capacity:
+                dpName: AzureDataSource_blobs_capacity
+                legend: Capacity
+      AzureSubnet:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureSubscription:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            cycletime: 300
+            datapoints:
+              current_core_count: {}
+              current_hosted_services: {}
+              current_storage_accounts: {}
+              max_core_count: {}
+              max_hosted_services: {}
+              max_storage_accounts: {}
+        graphs:
+          Cores:
+            units: Cores
+            miny: 0
+            graphpoints:
+              current_core_count:
+                dpName: AzureDataSource_current_core_count
+                legend: Current core count
+              max_core_count:
+                dpName: AzureDataSource_max_core_count
+                legend: Max core count
+          Hosted services:
+            units: Hosted services
+            miny: 0
+            graphpoints:
+              current_hosted_services:
+                dpName: AzureDataSource_current_hosted_services
+                legend: Current hosted services
+              max_hosted_services:
+                dpName: AzureDataSource_max_hosted_services
+                legend: Max hosted services
+          Storage accounts:
+            units: storage accounts
+            miny: 0
+            graphpoints:
+              current_storage_accounts:
+                dpName: AzureDataSource_current_storage_accounts
+                legend: Current storage accounts
+              max_storage_accounts:
+                dpName: AzureDataSource_max_storage_accounts
+                legend: Max storage accounts
+      AzureVirtualNetworkSite:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureWebSpace:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+
+"""
+
+YAML_PART1 = """
+name: ZenPacks.zenoss.Microsoft.Azure
+zProperties:
+  DEFAULTS:
+    category: Microsoft Azure
+  zAzureEAAccessKey:
+    default: ''
+  zAzureEAEnrollmentNumber:
+    default: ''
+  zAzureEABillingCostThreshold:
+    type: multilinethreshold
+    default: '{}'
+  zAzureMonitoringIgnore:
+    default: ''
+
+
+class_relationships:
+- AzureSubscription(affinity_groups) 1:MC (subscription)AzureAffinityGroup
+- AzureSubscription(hosted_services) 1:MC (subscription)AzureHostedService
+- AzureHostedService(instances) 1:MC (hosted_service)AzureInstance
+- AzureInstance(disks) 1:MC (instance)AzureDisk
+- AzureSubscription(storage_services) 1:MC (subscription)AzureStorageService
+- AzureStorageService(queues) 1:MC (storage_service)AzureQueue
+- AzureStorageService(tables) 1:MC (storage_service)AzureTable
+- AzureStorageService(containers) 1:MC (storage_service)AzureContainer
+- AzureContainer(blobs) 1:MC (container)AzureBlob
+- AzureSubscription(web_spaces) 1:MC (subscription)AzureWebSpace
+- AzureWebSpace(sites) 1:MC (web_space)AzureSite
+- AzureSubscription(virtual_network_sites) 1:MC (subscription)AzureVirtualNetworkSite
+- AzureVirtualNetworkSite(subnets) 1:MC (virtual_network_site)AzureSubnet
+- AzureSubscription(locations) 1:MC (subscription)AzureLocation
+
+
+classes:
+  DEFAULTS:
+    base: [AzureComponent]
+
+  AzureComponent:
+    base: [zenpacklib.Component]
+
+  SubscriptionObject:
+    base: [AzureComponent]
+    properties:
+      getSubscription:
+        label: Subscription
+        grid_display: true
+        api_only: true
+        api_backendtype: method
+        type: entity
+        order: 1
+        content_width: 90
+
+  AzureServiceObject:
+    base: [AzureComponent]
+    properties:
+      service_status:
+        label: Service Status
+        grid_display: true
+        content_width: 90
+        order: 2
+
+  AzureStatusObject:
+    base: [AzureComponent]
+    properties:
+      status:
+        label: Status
+        api_only: true
+        api_backendtype: method
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        content_width: 60
+        order: 10
+
+  AzureSubscription:
+    base: [zenpacklib.Device]
+    label: Subscription
+    properties:
+      DEFAULTS:
+        grid_display: false
+      subscription_id:
+        label: Subscription ID
+      cert_file:
+        label: Cert File
+      service_status:
+        label: Service Status
+      max_core_count:
+        label: Max Core Count
+      max_storage_accounts:
+        label: Max Storage Accounts
+      max_hosted_services:
+        label: Max Hosted Services
+      max_virtual_network_sites:
+        label: Max Virtual Network Sites
+      max_local_network_sites:
+        label: Max Local Network Sites
+      max_dns_servers:
+        label: Max DNS Servers
+      current_core_count:
+        label: Current Core Count
+      current_hosted_services:
+        label: Current Hosted Services
+      current_storage_accounts:
+        label: Current Storage Accounts
+      model_time:
+        label: Model Time
+      first_seen:
+        label: First Seen
+        api_only: true
+        api_backendtype: method
+      last_change:
+        label: Last Change
+        api_only: true
+        api_backendtype: method
+    dynamicview_group: Subscription
+    dynamicview_relations:
+      impacts: [hosted_services, storage_services, web_spaces, virtual_network_sites, locations, affinity_groups]
+
+  AzureAffinityGroup:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Affinity Group
+    properties:
+      DEFAULTS:
+        grid_display: false
+      label:
+        label: Label
+      description:
+        label: Description
+        grid_display: true
+        order: 2
+      location:
+        label: Location
+        grid_display: true
+        order: 3
+      capabilities:
+        label: Capabilities
+        grid_display: true
+        order: 4
+      # prob should replace these 2 with relations
+      hosted_services:
+        label: Hosted Services
+      storage_services:
+        label: Storage Services
+    dynamicview_relations:
+      impacted_by: [subscription]
+    monitoring_templates: [AzureAffinityGroup]
+
+  AzureHostedService:
+    base: [SubscriptionObject,AzureServiceObject]
+    label: Hosted Service
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+      production_status:
+        label: Production Status
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        order: 7
+        content_width: 90
+      staging_status:
+        label: Staging Status
+        grid_display: true
+        renderer: Zenoss.render.azure_pingStatus
+        order: 8
+        content_width: 80
+      location:
+        label: Location
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 4
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 3
+      date_created:
+        label: Created
+        #grid_display: true
+        order: 5
+        content_width: 80
+      date_last_modified:
+        label: Last Modified
+        #grid_display: true
+        order: 6
+        content_width: 90
+    dynamicview_relations:
+      impacts: [instances]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureHostedService]
+
+  AzureStorageService:
+    base: [SubscriptionObject, AzureStatusObject, AzureServiceObject]
+    label: Storage Service
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+      location:
+        label: Location
+        grid_display: true
+        order: 4
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        content_width: 100
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        order: 3
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        content_width: 100
+    relationships:
+      DEFAULTS:
+        grid_display: false
+      tables: {
+      }
+      queues: {
+      }
+      containers: {
+      }
+    dynamicview_relations:
+      impacts: [containers, tables, queues]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureStorageService]
+
+  AzureWebSpace:
+    base: [SubscriptionObject, AzureStatusObject, AzureServiceObject]
+    label: Web Space
+    properties:
+      DEFAULTS:
+        grid_display: false
+      plan:
+        label: Plan
+      geo_location:
+        label: Geo Location
+      number_of_workers:
+        label: Workers
+      availability_state:
+        label: Availability State
+        order: 3
+        grid_display: true
+      compute_mode:
+        label: Compute Mode
+    relationships:
+      DEFAULTS:
+        grid_display: false
+      sites: {
+      }
+    dynamicview_relations:
+      impacts: [sites]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureWebSpace]
+
+  AzureVirtualNetworkSite:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Virtual Network Site
+    properties:
+      DEFAULTS:
+        grid_display: false
+      label:
+        label: Label
+        grid_display: true
+      vn_id:
+        label: VN ID
+        grid_display: true
+        order: 2
+      affinity_group:
+        label: Affinity Group
+        grid_display: true
+        renderer: Zenoss.render.azure_entityLinkFromGrid
+        order: 3
+      state:
+        label: State
+        grid_display: true
+        order: 4
+    dynamicview_relations:
+      impacts: [subnets]
+      impacted_by: [subscription]
+    monitoring_templates: [AzureVirtualNetworkSite]
+
+  AzureLocation:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Location
+    dynamicview_relations:
+      impacted_by: [subscription]
+    monitoring_templates: [AzureLocation]
+
+  AzureInstance:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Instance
+    properties:
+      DEFAULTS:
+        grid_display: false
+      instance_status:
+        label: Instance Status
+        grid_display: true
+        order: 2
+      instance_size:
+        label: Instance Size
+      ip_address:
+        label: IP Address
+        grid_display: true
+        order: 3
+      power_state:
+        label: Power State
+        grid_display: true
+        order: 4
+      instance_error_code:
+        label: Instance Error Code
+      fqdn:
+        label: FQDN
+    dynamicview_relations:
+      impacted_by: [disks, hosted_service]
+    monitoring_templates: [AzureInstance]
+
+  AzureBlob:
+    label: Blob
+    base: [AzureStatusObject]
+    properties:
+      DEFAULTS:
+        grid_display: false
+      snapshot:
+        label: Snapshot
+      url:
+        label: URL
+      snapshot:
+        label: Snapshot
+      content_length:
+        label: Content Length
+        grid_display: true
+        order: 2
+      content_type:
+        label: Content Type
+        grid_display: true
+        order: 3
+      blob_type:
+        label: Blob Type
+        grid_display: true
+        order: 4
+      lease_status:
+        label: Lease Status
+        grid_display: true
+        order: 5
+      attached:
+        label: Attached Status
+        grid_display: false
+    dynamicview_relations:
+      impacted_by: [container]
+    monitoring_templates: [AzureBlob]
+
+  AzureContainer:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Container
+    properties:
+      DEFAULTS:
+        grid_display: true
+      url:
+        label: URL
+        order: 3
+      last_modified:
+        label: Last Modified
+        order: 2
+    dynamicview_relations:
+      impacts: [blobs]
+      impacted_by: [storage_service]
+    monitoring_templates: [AzureContainer]
+
+  AzureDisk:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Disk
+    properties:
+      DEFAULTS:
+        grid_display: false
+      affinity_group:
+        label: Affinity Group
+      has_operating_system:
+        label: Has Operating System
+      is_corrupted:
+        label: Is Corrupted
+      location:
+        label: Location
+        grid_display: true
+        order: 2
+      logical_disk_size_in_gb:
+        label: Logical Disk Size In GB
+        short_label: Size
+        grid_display: true
+        order: 4
+      label:
+        label: Label
+      media_link:
+        label: Media Link
+      os:
+        label: OS
+        grid_display: true
+        order: 3
+      source_image_name:
+        label: Source Image Name
+    dynamicview_relations:
+      impacts: [instance]
+    monitoring_templates: [AzureDisk]
+
+  AzureQueue:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Queue
+    properties:
+      DEFAULTS:
+        grid_display: false
+      url:
+        label: URL
+    dynamicview_relations:
+      impacted_by: [subscription, storage_service]
+    monitoring_templates: [AzureQueue]
+
+  AzureSite:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Site
+    properties:
+      DEFAULTS:
+        grid_display: false
+      state:
+        label: State
+      server_farm:
+        label: Server Farm
+      owner:
+        label: Owner
+      availability_state:
+        label: Availability State
+        grid_display: true
+        order: 2
+      runtime_availability_state:
+        label: Runtime Availability
+        #grid_display: true
+        #order: 3
+      admin_enabled:
+        label: Admin Enabled
+        grid_display: true
+        order: 5
+      compute_mode:
+        label: Compute Mode
+      enabled:
+        label: Enabled
+      host_names:
+        label: Host Names
+        #grid_display: true
+        #order: 6
+        renderer: Zenoss.render.azure_URL
+      enabled_host_names:
+        label: Enabled Host Names
+      self_link:
+        label: Self Link
+      usage_state:
+        label: Usage State
+        grid_display: true
+        order: 4
+    dynamicview_relations:
+      impacted_by: [web_space]
+    monitoring_templates: [AzureSite]
+
+  AzureSubnet:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Subnet
+    properties:
+      DEFAULTS:
+        grid_display: true
+      address_prefix:
+        label: Address Prefix
+        order: 2
+    dynamicview_relations:
+      impacted_by: [virtual_network_site]
+    monitoring_templates: [AzureSubnet]
+
+  AzureTable:
+    base: [SubscriptionObject, AzureStatusObject]
+    label: Table
+    properties:
+      DEFAULTS:
+        grid_display: false    
+    dynamicview_relations:
+      impacted_by: [subscription, storage_service]
+    monitoring_templates: [AzureTable]
+"""
+
+YAML_PART2 = """
+
+
+device_classes:
+  /Azure:
+    remove: true
+    zProperties:
+      zPythonClass: ZenPacks.zenoss.Microsoft.Azure.AzureSubscription
+      zCollectorPlugins:
+        - AzureCollector
+      zDeviceTemplates:
+        - AzureSubscription
+    templates:
+      AzureAffinityGroup:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureBlob:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 1800
+      AzureContainer:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureDisk:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureHostedService:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureInstance:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureSite:
+        targetPythonClass: ZenPacks.zenoss.Microsoft.Azure.AzureSite
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+            datapoints:
+              bytes_received:
+                aliases: {bytes_received: null}
+              bytes_sent:
+                aliases: {bytes_sent: null}
+              cpu_time:
+                aliases: {cpu_time: null}
+              filesystem_storage:
+                aliases: {filesystem_storage: null}
+              local_bytes_read:
+                aliases: {local_bytes_read: null}
+              local_bytes_written:
+                aliases: {local_bytes_written: null}
+              memory_usage:
+                aliases: {memory_usage: null}
+        graphs:
+          Bytes:
+            units: Bytes
+            graphpoints:
+              bytes_received:
+                dpName: AzureDataSource_bytes_received
+                legend: Received
+              bytes_sent:
+                dpName: AzureDataSource_bytes_sent
+                legend: Sent
+              local_bytes_read:
+                dpName: AzureDataSource_local_bytes_read
+                legend: Local bytes read
+              local_bytes_written:
+                dpName: AzureDataSource_local_bytes_written
+                legend: Local bytes written
+          CPU time:
+            units: Miliseconds
+            graphpoints:
+              cpu_time:
+                dpName: AzureDataSource_cpu_time
+                legend: CPU time
+          Filesystem:
+            units: Bytes
+            graphpoints:
+              filesystem_storage:
+                dpName: AzureDataSource_filesystem_storage
+                legend: Storage
+          Memory:
+            units: Bytes
+            graphpoints:
+              memory_usage:
+                dpName: AzureDataSource_memory_usage
+                legend: Usage
+      AzureStorageService:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+            datapoints:
+              blobs_capacity:
+                aliases: {blobs_capacity: null}
+              blobs_container_count:
+                aliases: {blobs_container_count: null}
+              blobs_object_count:
+                aliases: {blobs_object_count: null}
+        graphs:
+          Blobs:
+            units: Count
+            miny: 0
+            maxy: 0
+            graphpoints:
+              blobs_container_count:
+                dpName: AzureDataSource_blobs_container_count
+                legend: Container count
+              blobs_object_count:
+                dpName: AzureDataSource_blobs_object_count
+                legend: Object count
+          Blobs capacity:
+            units: Bytes
+            graphpoints:
+              blobs_capacity:
+                dpName: AzureDataSource_blobs_capacity
+                legend: Capacity
+      AzureSubnet:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureSubscription:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            cycletime: 300
+            datapoints:
+              current_core_count: {}
+              current_hosted_services: {}
+              current_storage_accounts: {}
+              max_core_count: {}
+              max_hosted_services: {}
+              max_storage_accounts: {}
+        graphs:
+          Cores:
+            units: Cores
+            miny: 0
+            graphpoints:
+              current_core_count:
+                dpName: AzureDataSource_current_core_count
+                legend: Current core count
+              max_core_count:
+                dpName: AzureDataSource_max_core_count
+                legend: Max core count
+          Hosted services:
+            units: Hosted services
+            miny: 0
+            graphpoints:
+              current_hosted_services:
+                dpName: AzureDataSource_current_hosted_services
+                legend: Current hosted services
+              max_hosted_services:
+                dpName: AzureDataSource_max_hosted_services
+                legend: Max hosted services
+          Storage accounts:
+            units: storage accounts
+            miny: 0
+            graphpoints:
+              current_storage_accounts:
+                dpName: AzureDataSource_current_storage_accounts
+                legend: Current storage accounts
+              max_storage_accounts:
+                dpName: AzureDataSource_max_storage_accounts
+                legend: Max storage accounts
+      AzureVirtualNetworkSite:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+      AzureWebSpace:
+        datasources:
+          AzureDataSource:
+            type: AzureDataSource
+            component: ${here/id}
+            cycletime: 300
+
+"""
+
+
+class TestMultiYAML(BaseTestCase):
+    """Test removal of undefined relations"""
+
+    def test_multi_yaml(self):
+        ''''''
+        
+        # reference yaml (all in one
+        cfg_whole = zenpacklib.load_yaml(YAML_WHOLE)
+
+        # reference yaml split across multiple files
+        cfg_multi = zenpacklib.load_yaml([YAML_PART1, YAML_PART2])
+
+        # dump both back to YAML
+        whole_yaml = yaml.dump(cfg_whole.specparams, Dumper=Dumper)
+        multi_yaml = yaml.dump(cfg_multi.specparams, Dumper=Dumper)
+
+        compare_equals = compare_zenpackspecs(whole_yaml, multi_yaml)
+
+        self.assertTrue(compare_equals, 
+                        'YAML Multiple file test failed')
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestMultiYAML))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_optimized_yaml.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_optimized_yaml.py
@@ -1,0 +1,716 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+""" Multi-YAML import load
+
+Tests YAML loading from multiple files
+
+"""
+# stdlib Imports
+import os
+import site
+import tempfile
+import traceback
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+# zenpacklib Imports
+from ZenPacks.zenoss.ZenPackLib import zenpacklib
+import yaml
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Dumper import Dumper
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Loader import Loader
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.utils import optimize_yaml, compare_zenpackspecs
+
+
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+
+YAML_WHOLE = """
+name: ZenPacks.zenoss.Microsoft.Windows
+zProperties:
+  DEFAULTS:
+    category: Windows
+  zWinRMUser:
+    default: ''
+  zWinRMPassword:
+    type: password
+    default: ''
+  zWinRMUser:
+    default: ''
+  zWinRMServerName:
+    default: ''
+  zWinRMPort:
+    default: '5985'
+  zDBInstances:
+    type: instancecredentials
+    default: '[{"instance": "MSSQLSERVER", "user": "", "passwd": ""}]'
+    category: 'Misc'
+  zWinKDC:
+    default: ''
+  zWinKeyTabFilePath:
+    default: ''
+  zWinScheme:
+    default: 'http'
+  zWinPerfmonInterval:
+    default: 300
+  zWinTrustedRealm:
+    default: ''
+  zWinTrustedKDC:
+    default: ''
+
+
+class_relationships:
+  - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmservices) 1:MC (os)WinService
+  - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmiis) 1:MC (os)WinIIS
+  - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winsqlinstances) 1:MC (os)WinSQLInstance
+  - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(clusterservices) 1:MC (os)ClusterService
+  - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(clusternetworks) 1:MC (os)ClusterNetwork
+  - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(clusternodes) 1:MC (os)ClusterNode
+  - ClusterService(clusterresources) 1:MC (clusterservice)ClusterResource
+  - ClusterNode(clusterdisks) 1:MC (clusternode)ClusterDisk
+  - ClusterNode(clusterinterfaces) 1:MC (clusternode)ClusterInterface
+  - WinSQLInstance(backups) 1:MC (winsqlinstance)WinSQLBackup
+  - WinSQLInstance(databases) 1:MC (winsqlinstance)WinSQLDatabase
+  - WinSQLInstance(jobs) 1:MC (winsqlinstance)WinSQLJob
+  - TeamInterface(teaminterfaces) 1:M (teaminterface)Interface
+
+
+classes:
+  DEFAULTS:
+    base: [BaseComponent]
+
+  BaseDevice:
+    base: [zenpacklib.Device]
+  
+  BaseComponent:
+    base: [zenpacklib.Component, Products.ZenModel.OSComponent.OSComponent]
+
+  ClusterObject:
+    base: [BaseComponent]
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      getState:
+        label: State
+        api_only: true
+        api_backendtype: method
+        grid_display: true
+        order: 7
+      domain:
+        label: Domain
+        default: ''
+
+  ClusterNodeObject:
+    base: [ClusterObject]
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      ownernode:
+        label: Owner Node
+      get_host_device:
+        label: Cluster Node
+        grid_display: true
+        api_only: true
+        api_backendtype: method
+        type: entity
+        order: 1
+
+  Device:
+    base: [BaseDevice]
+    label: Device
+    properties:
+      clusterdevices:
+        label: Cluster Devices
+        default: ''
+      sqlhostname:
+        label: SQL Host Name
+        default: None
+      msexchangeversion:
+        label: MS Exchange Version
+        default: None
+      ip_and_hostname:
+        default: None
+      domain_controller:
+        label: MS Exchange Version
+        type: boolean
+        default: false
+    impacts:
+      - all_filesystems
+      - all_processes
+      - all_ipservices
+      - all_cpus
+      - all_interfaces
+      - all_clusterservices
+      - all_clusternodes
+      - all_clusternetworks
+      - all_winservices
+      - all_hyperv
+      - all_winsqlinstances
+      - all_winrmiis
+    impacted_by: []
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts:
+        - all_filesystems
+        - all_processes
+        - all_ipservices
+        - all_cpus
+        - all_interfaces
+        - all_clusterservices
+        - all_clusternodes
+        - all_clusternetworks
+        - all_winservices
+        - all_hyperv
+        - all_winsqlinstances
+        - all_winrmiis
+      impacted_by: []
+
+  ClusterDevice:
+    base: [Device]
+    properties:
+      clusterhostdevices:
+        label: Cluster Host Devices
+        default: ''
+      GUID:
+        label: GUID
+        default: None
+      creatingdc:
+        label: Creating DC
+        default: None
+    impacts:
+      - all_filesystems
+      - all_processes
+      - all_ipservices
+      - all_cpus
+      - all_interfaces
+      - all_clusterservices
+      - all_clusternodes
+      - all_clusternetworks
+      - all_winservices
+      - all_hyperv
+      - all_winsqlinstances
+      - all_winrmiis
+    impacted_by: [all_clusterhosts]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts:
+        - all_filesystems
+        - all_processes
+        - all_ipservices
+        - all_cpus
+        - all_interfaces
+        - all_clusterservices
+        - all_clusternodes
+        - all_clusternetworks
+        - all_winservices
+        - all_hyperv
+        - all_winsqlinstances
+        - all_winrmiis
+      impacted_by: [all_clusterhosts]
+
+  ClusterResource:
+    label: Cluster Resource
+    base: [ClusterNodeObject]
+    order: 5
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      description:
+        label: Description
+      ownergroup:
+        label: Owner Group
+        type: boolean
+        default: False
+    monitoring_templates: [ClusterResource]
+    impacts: []
+    impacted_by: [device, clusterservice]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [clusterservice]
+
+  ClusterService:
+    label: Cluster Service
+    base: [ClusterNodeObject]
+    order: 6
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      description:
+        label: Description
+      coregroup:
+        label: Core Group
+        type: boolean
+        default: False
+      priority:
+        label: Priority
+        type: int
+        default: 0
+    monitoring_templates: [ClusterService]
+    impacts: [clusterresources]
+    impacted_by: [device]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: [clusterresources]
+      impacted_by: [device]
+    relationships:
+      DEFAULTS:
+        grid_display: false
+        details_display: false
+      os: {}
+
+  ClusterNode:
+    label: Cluster Node
+    base: [ClusterNodeObject]
+    order: 1
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      assignedvote:
+        label: Assigned Vote
+        grid_display: true
+        order: 2
+      currentvote:
+        label: Current Vote
+        grid_display: true
+        order: 3
+    monitoring_templates: [ClusterNode]
+    impacts: []
+    impacted_by: [clusterdisks, clusterinterfaces]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [clusterdisks, clusterinterfaces]
+    relationships:
+      DEFAULTS:
+        grid_display: false
+        details_display: false
+      os: {}
+
+  ClusterDisk:
+    label: Cluster Disk
+    base: [ClusterNodeObject]
+    order: 2
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      volumepath:
+        label: Volume Path
+      disknumber:
+        label: Disk Number
+      partitionnumber:
+        label: Partition Number
+      size:
+        label: Size
+        grid_display: true
+        order: 5
+      freespace:
+        label: Free Space
+        grid_display: true
+        order: 6
+      assignedto:
+        label: Assigned To
+        grid_display: true
+        order: 2
+    monitoring_templates: [ClusterDisk]
+    impacts: [clusternode]
+    impacted_by: []
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: [clusternode]
+      impacted_by: []
+
+  ClusterNetwork:
+    label: Cluster Network
+    base: [ClusterObject]
+    order: 4
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      description:
+        label: Description
+        grid_display: true
+        order: 3
+      role:
+        label: Cluster Use
+        type: boolean
+        default: False
+        grid_display: true
+        order: 2
+    monitoring_templates: [ClusterNetwork]
+    impacts: []
+    impacted_by: [device]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [device]
+    relationships:
+      DEFAULTS:
+        grid_display: false
+        details_display: false
+      os: {}
+
+  ClusterInterface:
+    label: Cluster Interface
+    base: [ClusterObject]
+    order: 3
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      node:
+        label: Node
+      get_network:
+        label: Network
+        grid_display: true
+        api_only: true
+        api_backendtype: method
+        type: entity
+        order: 2
+      network:
+        label: Network
+      ipaddresses:
+        label: IP Addresses
+        grid_display: true
+        order: 3
+      adapter:
+        label: Adapter
+    monitoring_templates: [ClusterInterface]
+    impacts: [clusternode]
+    impacted_by: []
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: [clusternode]
+      impacted_by: []
+
+  CPU:
+    label: Processor
+    base: [zenpacklib.Component, Products.ZenModel.CPU.CPU]
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: 0
+        type: int
+      description:
+        label: Description
+        type: string
+        default: None
+      cores:
+        label: Cores
+      cores:
+        label: Cores
+      threads:
+        label: Threads
+      cacheSpeedL2:
+        label: L2 Cache Speed
+      cacheSpeedL3:
+        label: L3 Cache Speed
+      cacheSizeL3:
+        label: L3 Cache Size
+        grid_display: true
+    monitoring_templates: [CPU]
+    impacts: []
+    impacted_by: [device]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [device]
+
+  FileSystem:
+    label: File System
+    base: [BaseComponent, Products.ZenModel.FileSystem.FileSystem]
+    properties:
+      DEFAULTS:
+        details_display: false
+        grid_display: false
+      mediatype:
+        label: Media Type
+        default: None
+      drivetype:
+        label: Drive Type
+        default: None
+      total_bytes:
+        type: long
+        label: Total Bytes
+        default: 0
+    monitoring_templates: [FileSystem]
+    impacts: []
+    impacted_by: [device]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [device]
+
+  Interface:
+    label: Interface
+    base: [BaseComponent, Products.ZenModel.IpInterface.IpInterface]
+    monitoring_templates: [ethernetCsmacd]
+    impacts: []
+    impacted_by: [device]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [device]
+    relationships:
+      DEFAULTS:
+        grid_display: true
+        details_display: false
+      teaminterface: {}
+
+  OSProcess:
+    label: Process
+    base: [BaseComponent, Products.ZenModel.OSProcess.OSProcess]
+    monitoring_templates: [OSProcess]
+    properties:
+      supports_WorkingSetPrivate:
+        label: Supports Private Working Set
+        type: boolean
+        default: False
+    impacts: []
+    impacted_by: [device]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [device]
+
+  TeamInterface:
+    label: Team Interface
+    base: [BaseComponent, Products.ZenModel.IpInterface.IpInterface]
+    monitoring_templates: [TeamInterface]
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      description:
+        label: Description
+      get_niccount:
+        type: int
+        label: NIC Count
+        default: 0
+        api_only: true
+        api_backendtype: method
+    impacts: []
+    impacted_by: [device]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [device]
+
+  WinIIS:
+    label: IIS Site
+    plural_label: IIS Sites
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      sitename:
+        label: Site Name
+      apppool:
+        label: Application Pool
+        grid_display: true
+        order: 2
+      caption:
+        label: Caption
+      status:
+        label: Status
+        grid_display: true
+        order: 3
+      statusname:
+        label: Status Name
+      iis_version:
+        label: Version
+        type: int
+    monitoring_templates: [IISSites]
+    impacts: []
+    impacted_by: [device]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [device]
+    relationships:
+      DEFAULTS:
+        grid_display: false
+        details_display: false
+      os: {}
+
+  WinSQLBackup:
+    label: SQL Backup
+    order: 13
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      instancename:
+        label: Instance Name
+      devicetype:
+        label: Device Type
+        grid_display: true
+        order: 1
+      physicallocation:
+        label: Physical Location
+      status:
+        label: Status
+    monitoring_templates: [WinBackupDevice]
+    impacts: []
+    impacted_by:  [winsqlinstance]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by:  [winsqlinstance]
+
+  WinSQLDatabase:
+    label: SQL Database
+    order: 11
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      instancename:
+        label: Instance Name
+      version:
+        label: Version
+      owner:
+        label: Owner
+        grid_display: true
+        order: 1
+      lastbackupdate:
+        label: Last Backup
+      lastlogbackupdate:
+        label: Last Log Backup
+      isaccessible:
+        label: Accessible
+      collation:
+        label: Collation
+      createdate:
+        label: Created On
+      defaultfilegroup:
+        label: File Group
+      primaryfilepath:
+        label: File Path
+      systemobject:
+        label: System Object
+      recoverymodel:
+        label: Recovery Model
+      status:
+        label: Status
+        grid_display: true
+        order: 3
+      cluster_node_server:
+        label: Cluster Node Server
+    monitoring_templates: [WinDatabase]
+    impacts: []
+    impacted_by: [winsqlinstance]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [winsqlinstance]
+
+  WinSQLInstance:
+    label: SQL Instance
+    order: 10
+    properties:
+      DEFAULTS:
+        grid_display: false
+        default: None
+      instancename:
+        label: Instance Name
+        grid_display: true
+      backupdevices:
+        label: Backup Devices
+      roles:
+        label: Roles
+      cluster_node_server:
+        label: Cluster Node Server
+    monitoring_templates: [WinDBInstance]
+    impacts: [backups, databases, jobs]
+    impacted_by: [device]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: [backups, databases, jobs]
+      impacted_by: [device]
+    relationships:
+      DEFAULTS:
+        grid_display: false
+        details_display: false
+      os: {}
+
+  WinSQLJob:
+    label: SQL Job
+    order: 12
+    properties:
+      DEFAULTS:
+        grid_display: false
+        #default: None
+      instancename:
+        label: Instance Name
+      jobid:
+        label: Job ID
+      enabled:
+        label: Enabled
+        grid_display: true
+        order: 1
+      description:
+        label: Description
+      username:
+        label: User
+        #default: None
+      datecreated:
+        label: Date Created
+      cluster_node_server:
+        label: Cluster Node Server
+    monitoring_templates: [WinSQLJob]
+    impacts: []
+    impacted_by: [winsqlinstance]
+    dynamicview_views: [service_view]
+    dynamicview_relations:
+      impacts: []
+      impacted_by: [winsqlinstance]
+"""
+
+
+
+class TestOptimizedYAML(BaseTestCase):
+    """Test optimized YAML"""
+
+    def test_optimized_yaml(self):
+        ''''''
+        # reference yaml (all in one
+
+        cfg = zenpacklib.load_yaml(YAML_WHOLE)
+        orig_yaml = yaml.dump(cfg.specparams, Dumper=Dumper)
+        new_yaml = optimize_yaml(YAML_WHOLE)
+
+        compare_equals = compare_zenpackspecs(orig_yaml, new_yaml)
+
+        self.assertTrue(compare_equals, 
+                        'YAML Optimization test failed')
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestOptimizedYAML))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
+++ b/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
@@ -33,68 +33,17 @@ __version__ = "1.1.0dev"
 # BaseTestCase which puts Zope into testing mode.
 TestCase = None
 
-import yaml
-
 import Globals
 from Products.ZenUtils.Utils import unused
 unused(Globals)
 
-from lib.functions import load_yaml, represent_spec, \
-    represent_zenpackspec,  represent_relschemaspec, \
-    construct_zenpackspec, relationships_from_yuml
-from lib.helpers.Loader import Loader
-from lib.helpers.Dumper import Dumper
+# ZenPacks use these to load their YAML files
+from lib.helpers.utils import load_yaml
 
 # these are the base classes for zenpacklib.Device, zenpacklib.Component, zenpacklib.HardwareComponent
 from lib.base.Device import Device
 from lib.base.Component import Component
 from lib.base.HardwareComponent import HardwareComponent
-
-
-from lib.spec.ZenPackSpec import ZenPackSpec
-from lib.spec.DeviceClassSpec import DeviceClassSpec
-from lib.spec.ZPropertySpec import ZPropertySpec
-from lib.spec.ClassSpec import ClassSpec
-from lib.spec.ClassPropertySpec import ClassPropertySpec
-from lib.spec.ClassRelationshipSpec import ClassRelationshipSpec
-from lib.spec.RelationshipSchemaSpec import RelationshipSchemaSpec
-
-from lib.params.ZenPackSpecParams import ZenPackSpecParams
-from lib.params.DeviceClassSpecParams import DeviceClassSpecParams
-from lib.params.ZPropertySpecParams import ZPropertySpecParams
-from lib.params.ClassSpecParams import ClassSpecParams
-from lib.params.ClassPropertySpecParams import ClassPropertySpecParams
-from lib.params.ClassRelationshipSpecParams import ClassRelationshipSpecParams
-from lib.params.RRDTemplateSpecParams import RRDTemplateSpecParams
-from lib.params.RRDThresholdSpecParams import RRDThresholdSpecParams
-from lib.params.RRDDatasourceSpecParams import RRDDatasourceSpecParams
-from lib.params.RRDDatapointSpecParams import RRDDatapointSpecParams
-from lib.params.GraphDefinitionSpecParams import GraphDefinitionSpecParams
-from lib.params.GraphPointSpecParams import GraphPointSpecParams
-
-Dumper.add_representer(ZenPackSpec, represent_zenpackspec)
-Dumper.add_representer(DeviceClassSpec, represent_spec)
-Dumper.add_representer(ZPropertySpec, represent_spec)
-Dumper.add_representer(ClassSpec, represent_spec)
-Dumper.add_representer(ClassPropertySpec, represent_spec)
-Dumper.add_representer(ClassRelationshipSpec, represent_spec)
-Dumper.add_representer(RelationshipSchemaSpec, represent_relschemaspec)
-Loader.add_constructor(u'!ZenPackSpec', construct_zenpackspec)
-
-yaml.add_path_resolver(u'!ZenPackSpec', [], Loader=Loader)
-
-Dumper.add_representer(ZenPackSpecParams, represent_zenpackspec)
-Dumper.add_representer(DeviceClassSpecParams, represent_spec)
-Dumper.add_representer(ZPropertySpecParams, represent_spec)
-Dumper.add_representer(ClassSpecParams, represent_spec)
-Dumper.add_representer(ClassPropertySpecParams, represent_spec)
-Dumper.add_representer(ClassRelationshipSpecParams, represent_spec)
-Dumper.add_representer(RRDTemplateSpecParams, represent_spec)
-Dumper.add_representer(RRDThresholdSpecParams, represent_spec)
-Dumper.add_representer(RRDDatasourceSpecParams, represent_spec)
-Dumper.add_representer(RRDDatapointSpecParams, represent_spec)
-Dumper.add_representer(GraphDefinitionSpecParams, represent_spec)
-Dumper.add_representer(GraphPointSpecParams, represent_spec)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ AUTHOR = ""
 LICENSE = ""
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.zenoss']
 PACKAGES = ['ZenPacks', 'ZenPacks.zenoss', 'ZenPacks.zenoss.ZenPackLib']
-INSTALL_REQUIRES = []
+INSTALL_REQUIRES = ['PyYAML>=3.11']
 COMPAT_ZENOSS_VERS = ""
 PREV_ZENPACK_NAME = ""
 # STOP_REPLACEMENTS

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ AUTHOR = ""
 LICENSE = ""
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.zenoss']
 PACKAGES = ['ZenPacks', 'ZenPacks.zenoss', 'ZenPacks.zenoss.ZenPackLib']
-INSTALL_REQUIRES = ['PyYAML>=3.11']
+INSTALL_REQUIRES = []
 COMPAT_ZENOSS_VERS = ""
 PREV_ZENPACK_NAME = ""
 # STOP_REPLACEMENTS


### PR DESCRIPTION
- added capability to build a ZenPackSpec from multiple YAML files
(load_yaml_multi)
- build ZenPackSpec from YAML files in a directory (load_yaml_dir)
- optimize existing YAML file format and DEFAULTS (optimize_yaml)
- added -o (--optimize) switch to zenpacklib.py options
- added "compare_zenpackspec" to report whether different YAML documents
result in the same ZenPackSpec
- added unit tests "test_optimized_yaml" and "test_load_yaml_multi"
- refactor of Loader and Dumper classes
- converted all functions with "loader" or "dumper" parameters into
Loader/Dumper class functions
- added Dumper representer for Python Unicode and OrderedDict
- added Loader constructor for OrderedDict
- better order preservation when dumping ZenPackSpec to YAML (not 100%)
- removed extraneous "!!ZenPackSpec" and !!unicode annotations from
dumped YAML
- added 'type_map' method that attempts to determine python data type
(ZEN-24079)
- included python data type checking for extraparameters in
"construct_spec" (ZEN-24079)
- added zen-27049-extraparams.yaml for unit test validation
- added alphabetical sort order when building specs in
"specs_from_param", since this was tripping up inter-ZenPackSpec
comparison (OrderedDicts with different orders)
- removed unneeded imports from zenpacklib.py
- added imports for "load_yaml_multi" and "load_yaml_dir" to
zenpacklib.py
- added "self.colorindex" to GraphPointSpec and "self.shorthand" to
RRDDatapointSpec in __init__, since missing these was causing Exceptions
with multiple YAML load/dump cycles (part of the validation testing)
- updated to accommodate logging changes