### PR TITLE
Ensure that inherited relationship name overrides are displayed in details pane (ZenPack)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/wrapper/ComponentFormBuilder.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/wrapper/ComponentFormBuilder.py
@@ -6,11 +6,13 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+import zope.schema
 from zope.component import adapts
-from zope.interface import implements
+from zope.interface import implements, providedBy
 from Products.Zuul.form.interfaces import IFormBuilder
 from Products.Zuul.interfaces import IInfo
 from Products.Zuul.infos.component import ComponentFormBuilder as BaseComponentFormBuilder
+from ..functions import LOG
 
 
 class ComponentFormBuilder(BaseComponentFormBuilder):
@@ -23,6 +25,7 @@ class ComponentFormBuilder(BaseComponentFormBuilder):
 
     implements(IFormBuilder)
     adapts(IInfo)
+    LOG = LOG
 
     def render(self, **kwargs):
         rendered = super(ComponentFormBuilder, self).render(kwargs)
@@ -44,3 +47,33 @@ class ComponentFormBuilder(BaseComponentFormBuilder):
                         zenpack_id_prefix=self.zenpack_id_prefix)
                     item['renderer'] = renderer
 
+    def fields(self, fieldFilter=None):
+        """ override to ensure fields are inherited properly"""
+        d = {}
+
+        iface_fields = []
+        for iface in providedBy(self.context):
+            f = zope.schema.getFields(iface)
+            if f:
+                iface_fields.append(f)
+        # reverse so that subclasses processed last
+        iface_fields.reverse()
+
+        for f in iface_fields:
+            def _filter(item):
+                include = True
+                if fieldFilter:
+                    key=item[0]
+                    include = fieldFilter(key)
+                else:
+                    include = bool(item)
+                return include
+            for k,v in filter(_filter, f.iteritems()):
+                c = self._dict(v)
+                c['name'] = k
+                value =  getattr(self.context, k, None)
+                c['value'] = value() if callable(value) else value                    
+                if c['xtype'] in ('autoformcombo', 'itemselector'):
+                    c['values'] = self.vocabulary(v)
+                d[k] = c
+        return d


### PR DESCRIPTION
- Fixes ZEN-24303
- rewrite ComponentFormBuilder fields() method to ensure that subclass
overrides are honored