### PR TITLE
Fixes error messages for components properties

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -4951,7 +4951,8 @@ if YAML_INSTALLED:
         elif key in ZENOSS_KEYWORDS.union(JS_WORDS):
             # should be ok to use a zenoss word to define these
             # some items, like sysUpTime are pretty common datapoints
-            if cls not in [RRDDatasourceSpec,
+            if cls not in [ClassPropertySpec,
+                           RRDDatasourceSpec,
                            RRDDatapointSpec,
                            RRDTemplateSpec,
                            GraphDefinitionSpec,


### PR DESCRIPTION
Assume device components allowed to have properties named as in zenoss base classes