### PR TITLE
Fix logging and namespace issues preventing dependent ZenPack installation

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/CatalogBase.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/CatalogBase.py
@@ -8,7 +8,7 @@
 ##############################################################################
 from Products.ZenUtils.Search import makeFieldIndex, makeKeywordIndex
 from ..functions import catalog_search
-from ..functions import LOG
+from ..helpers.ZenPackLibLog import DEFAULTLOG
 
 
 class CatalogBase(object):
@@ -16,7 +16,7 @@ class CatalogBase(object):
 
     # By Default there is no default catalog created.
     _catalogs = {}
-    LOG=LOG
+    LOG=DEFAULTLOG
 
     def search(self, name, *args, **kwargs):
         """
@@ -128,20 +128,20 @@ class CatalogBase(object):
     @classmethod
     def _get_catalog_spec(cls, name):
         if not hasattr(cls, '_catalogs'):
-            LOG.error("{} has no catalogs defined".format(cls))
+            cls.LOG.error("{} has no catalogs defined".format(cls))
             return
 
         spec = cls._catalogs.get(name)
         if not spec:
-            LOG.error("{} catalog definition is missing".format(name))
+            cls.LOG.error("{} catalog definition is missing".format(name))
             return
 
         if not isinstance(spec, dict):
-            LOG.error("{} catalog definition is not a dict".format(name))
+            cls.LOG.error("{} catalog definition is not a dict".format(name))
             return
 
         if not spec.get('indexes'):
-            LOG.error("{} catalog definition has no indexes".format(name))
+            cls.LOG.error("{} catalog definition has no indexes".format(name))
             return
 
         return spec
@@ -212,7 +212,7 @@ class CatalogBase(object):
         for propname, propdata in spec['indexes'].items():
             index_type = propdata.get('type')
             if not index_type:
-                LOG.error("{} index has no type".format(propname))
+                cls.LOG.error("{} index has no type".format(propname))
                 return
 
             index_factory = {
@@ -221,7 +221,7 @@ class CatalogBase(object):
                 }.get(index_type.lower())
 
             if not index_factory:
-                LOG.error("{} is not a valid index type".format(index_type))
+                cls.LOG.error("{} is not a valid index type".format(index_type))
                 return
 
             try:
@@ -242,7 +242,7 @@ class CatalogBase(object):
                     try:
                         new_obj = result.getObject()
                     except Exception as e:
-                        LOG.error("Trying to index non-existent object {}".format(e))
+                        cls.LOG.error("Trying to index non-existent object {}".format(e))
                         continue
                     else:
                         if hasattr(new_obj, 'index_object'):

--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ClassProperty.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ClassProperty.py
@@ -6,7 +6,8 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-from ..functions import LOG
+from ..helpers.ZenPackLibLog import DEFAULTLOG
+
 
 class ClassProperty(property):
 
@@ -16,7 +17,7 @@ class ClassProperty(property):
     @ClassProperty decorator does, but only for getters.
 
     """
-    LOG=LOG
+    LOG=DEFAULTLOG
 
     def __get__(self, cls, owner):
         return self.fget.__get__(None, owner)()

--- a/ZenPacks/zenoss/ZenPackLib/lib/dynamicview.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/dynamicview.py
@@ -9,7 +9,7 @@
 import collections
 from zope.interface import implements
 from zope.component import adapts
-from .functions import LOG
+from .helpers.ZenPackLibLog import DEFAULTLOG
 from ZenPacks.zenoss.DynamicView import BaseRelation, BaseGroup
 from ZenPacks.zenoss.DynamicView import TAG_ALL
 from ZenPacks.zenoss.DynamicView.interfaces import IRelatable, IRelationsProvider
@@ -115,7 +115,7 @@ class DynamicViewRelationsProvider(BaseRelationsProvider):
         """Generate object relatables returned by adapted.methodname()."""
         method = getattr(self._adapted, methodname, None)
         if not method or not callable(method):
-            LOG.warning(
+            DEFAULTLOG.warning(
                 "no %r relationship or method for %r",
                 methodname,
                 self._adapted.meta_type)

--- a/ZenPacks/zenoss/ZenPackLib/lib/factory/ModelTypeFactory.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/factory/ModelTypeFactory.py
@@ -8,7 +8,7 @@
 ##############################################################################
 from collections import OrderedDict
 from ..base.ClassProperty import ClassProperty
-from ..functions import LOG
+from ..helpers.ZenPackLibLog import DEFAULTLOG
 
 
 def ModelTypeFactory(name, bases):
@@ -61,7 +61,7 @@ def ModelTypeFactory(name, bases):
         '_relations': _relations,
         'index_object': index_object,
         'unindex_object': unindex_object,
-        'LOG': LOG
+        'LOG': DEFAULTLOG
         }
 
     return type(name, bases, attributes)

--- a/ZenPacks/zenoss/ZenPackLib/lib/functions.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/functions.py
@@ -19,7 +19,7 @@ from Products.ZenModel.Device import Device as BaseDevice
 from Products.Zuul.infos.device import DeviceInfo as BaseDeviceInfo
 from Products.ZenModel.DeviceComponent import DeviceComponent as BaseDeviceComponent
 from Products.Zuul.infos.component import ComponentInfo as BaseComponentInfo
-from .helpers.ZenPackLibLog import LOG
+from .helpers.ZenPackLibLog import DEFAULTLOG
 
 
 # Private Functions ######################################################### 
@@ -112,7 +112,7 @@ def catalog_search(scope, name, *args, **kwargs):
 
     catalog = getattr(scope, '{}Search'.format(name), None)
     if not catalog:
-        LOG.debug("Catalog {}Search not found at {}.  It should be created when the first included component is indexed".format(name, scope))
+        DEFAULTLOG.debug("Catalog {}Search not found at {}.  It should be created when the first included component is indexed".format(name, scope))
         return []
 
     if args:

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -10,7 +10,7 @@ import yaml
 import re
 from yaml.representer import SafeRepresenter
 from collections import OrderedDict
-from ..functions import LOG
+from .ZenPackLibLog import DEFAULTLOG
 
 
 def get_zproperty_type(z_type):
@@ -36,7 +36,7 @@ class Dumper(yaml.Dumper):
         be used for this specific zenpacklib.
     """
 
-    LOG=LOG
+    LOG=DEFAULTLOG
 
     def dict_representer(self, data):
         return yaml.MappingNode(u'tag:yaml.org,2002:map', data.items())

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
@@ -14,7 +14,7 @@ import importlib
 import keyword
 from collections import OrderedDict
 from ..functions import ZENOSS_KEYWORDS, JS_WORDS, relname_from_classname, find_keyword_cls
-from .ZenPackLibLog import ZPLOG, LOG
+from .ZenPackLibLog import ZPLOG, DEFAULTLOG
 from .Dumper import get_zproperty_type
 
 
@@ -26,7 +26,7 @@ class Loader(yaml.Loader):
         be used for this specific zenpacklib.
     """
 
-    LOG=LOG
+    LOG=DEFAULTLOG
     QUIET=False
     LEVEL=0
 
@@ -270,7 +270,7 @@ class Loader(yaml.Loader):
 
         from ..spec.ZenPackSpec import ZenPackSpec
         params = self.construct_spec(ZenPackSpec, node)
-        params['log'] = self.LOG
+        params['zplog'] = self.LOG
         name = params.pop("name")
 
         fatal = not getattr(self, 'warnings', False)

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/ZenPackLibLog.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/ZenPackLibLog.py
@@ -23,13 +23,13 @@ def new_log(id):
         logging.basicConfig()
     return log
 
-LOG = new_log('zpl.zenpacklib')
+DEFAULTLOG = new_log('zpl.zenpacklib')
 
 
 class ZenPackLibLog(object):
     ''''''
     zenpacks = {}
-    defaultlog = LOG
+    defaultlog = DEFAULTLOG
 
     def get_log(self, id):
         if id in self.zenpacks.keys():

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
@@ -11,7 +11,7 @@ import logging
 from collections import OrderedDict
 import yaml
 import time
-from .ZenPackLibLog import LOG
+from .ZenPackLibLog import DEFAULTLOG
 from .Dumper import Dumper
 from .Loader import Loader
 import inspect
@@ -52,7 +52,7 @@ def load_yaml(yaml_doc=None, verbose=False, level=0):
         try:
             return load_yaml(get_calling_dir(), verbose, level)
         except Exception as e:
-            LOG.error("YAML load error %s" % e)
+            DEFAULTLOG.error("YAML load error %s" % e)
     # loading from multiple files
     if isinstance(yaml_doc, list):
         # build python dict of merged YAML data
@@ -69,7 +69,7 @@ def load_yaml(yaml_doc=None, verbose=False, level=0):
                 # if we already have a ZP id, but this yaml
                 # has a different one, then there's a problem.
                 if name and name != zp_id:
-                    LOG.error('Skipping {} because multiple ZenPack names found: {} vs {}'.format(f, zp_id, name))
+                    DEFAULTLOG.error('Skipping {} because multiple ZenPack names found: {} vs {}'.format(f, zp_id, name))
                     continue
             # update the python dict
             cfg_data.update(f_cfg)
@@ -95,18 +95,18 @@ def load_yaml(yaml_doc=None, verbose=False, level=0):
 
     try:
         if os.path.isfile(yaml_doc):
-            LOG.info("Loading YAML from {}".format(yaml_doc))
+            DEFAULTLOG.info("Loading YAML from {}".format(yaml_doc))
         CFG = load_yaml_single(yaml_doc)
     except Exception as e:
-        LOG.error(e)
+        DEFAULTLOG.error(e)
 
     if CFG:
         CFG.create()
     else:
-        LOG.error("Unable to load {}".format(yaml_doc))
+        DEFAULTLOG.error("Unable to load {}".format(yaml_doc))
 
     end = time.time() - start
-    LOG.info("Loaded {} in {:0.2f}s".format(CFG.name, end))
+    DEFAULTLOG.info("Loaded {} in {:0.2f}s".format(CFG.name, end))
 
     return CFG
 
@@ -141,7 +141,7 @@ def optimize_yaml(yaml_doc):
     # new load
     valid = compare_zenpackspecs(orig_yaml, optimized_yaml)
     if not valid:
-        LOG.warn('OPTIMIZATION FAILED VERIFICATION!  Please review optimized YAML prior to use ')
+        DEFAULTLOG.warn('OPTIMIZATION FAILED VERIFICATION!  Please review optimized YAML prior to use ')
     return optimized_yaml
 
 
@@ -157,7 +157,7 @@ def compare_zenpackspecs(orig_yaml, new_yaml):
     new.create()
     # SpecParams should be equal
     if orig != new:
-        LOG.warn('ZenPackSpec mismatch between original and new')
+        DEFAULTLOG.warn('ZenPackSpec mismatch between original and new')
         dict_compare(orig.__dict__, new.__dict__)
     # now dump new specs back out to yaml
     orig_dump = yaml.dump(orig.specparams, Dumper=Dumper)
@@ -167,7 +167,7 @@ def compare_zenpackspecs(orig_yaml, new_yaml):
     new_raw_yaml = load_yaml_single(new_dump, useLoader=False)
     # these should also be equivalent
     if orig_raw_yaml != new_raw_yaml:
-        LOG.warn('YAML loaded Python dictionary mismatch between original and new')
+        DEFAULTLOG.warn('YAML loaded Python dictionary mismatch between original and new')
         dict_compare(orig_raw_yaml, new_raw_yaml)
         return False
     return True
@@ -180,9 +180,9 @@ def dict_compare(d1, d2):
     removed = d2_keys - d1_keys
     modified = {o : (d1[o], d2[o]) for o in intersect_keys if d1[o] != d2[o]}
     same = set(o for o in intersect_keys if d1[o] == d2[o])
-    LOG.warn('ADDED: {}'.format(added))
-    LOG.warn('REMOVED: {}'.format(removed))
-    LOG.warn('MODIFIED: {}'.format(modified))
+    DEFAULTLOG.warn('ADDED: {}'.format(added))
+    DEFAULTLOG.warn('REMOVED: {}'.format(removed))
+    DEFAULTLOG.warn('MODIFIED: {}'.format(modified))
 
 
 def get_optimized_yaml(data):

--- a/ZenPacks/zenoss/ZenPackLib/lib/impact.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/impact.py
@@ -9,7 +9,7 @@
 from zope.interface import implements
 from zope.component import adapts
 from Products.ZenUtils.guid.interfaces import IGlobalIdentifier
-from .functions import LOG
+from .helpers.ZenPackLibLog import DEFAULTLOG
 from .base.ComponentBase import ComponentBase
 from .base.DeviceBase import DeviceBase
 from ZenPacks.zenoss.Impact.impactd.relations import ImpactEdge
@@ -74,7 +74,7 @@ class ImpactRelationshipDataProvider(object):
         """Generate object GUIDs returned by adapted.methodname()."""
         method = getattr(self.adapted, methodname, None)
         if not method or not callable(method):
-            LOG.warning(
+            DEFAULTLOG.warning(
                 "no %r relationship or method for %r",
                 methodname,
                 self.adapted.meta_type)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassSpecParams.py
@@ -27,8 +27,8 @@ class ClassSpecParams(SpecParams, ClassSpec):
             self.monitoring_templates = [monitoring_templates]
 
         self.properties = self.specs_from_param(
-            ClassPropertySpecParams, 'properties', properties, leave_defaults=True, log=self.LOG)
+            ClassPropertySpecParams, 'properties', properties, leave_defaults=True, zplog=self.LOG)
 
         self.relationships = self.specs_from_param(
-            ClassRelationshipSpecParams, 'relationships', relationships, leave_defaults=True, log=self.LOG)
+            ClassRelationshipSpecParams, 'relationships', relationships, leave_defaults=True, zplog=self.LOG)
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/DeviceClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/DeviceClassSpecParams.py
@@ -17,4 +17,4 @@ class DeviceClassSpecParams(SpecParams, DeviceClassSpec):
         self.path = path
         self.zProperties = zProperties
         self.templates = self.specs_from_param(
-            RRDTemplateSpecParams, 'templates', templates, log=self.LOG)
+            RRDTemplateSpecParams, 'templates', templates, zplog=self.LOG)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/GraphDefinitionSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/GraphDefinitionSpecParams.py
@@ -20,7 +20,7 @@ class GraphDefinitionSpecParams(SpecParams, GraphDefinitionSpec):
         SpecParams.__init__(self, **kwargs)
         self.name = name
         self.graphpoints = self.specs_from_param(
-            GraphPointSpecParams, 'graphpoints', graphpoints, log=self.LOG)
+            GraphPointSpecParams, 'graphpoints', graphpoints, zplog=self.LOG)
 
     @classmethod
     def fromObject(cls, graphdefinition):

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatasourceSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatasourceSpecParams.py
@@ -18,7 +18,7 @@ class RRDDatasourceSpecParams(SpecParams, RRDDatasourceSpec):
         self.name = name
 
         self.datapoints = self.specs_from_param(
-            RRDDatapointSpecParams, 'datapoints', datapoints, log=self.LOG)
+            RRDDatapointSpecParams, 'datapoints', datapoints, zplog=self.LOG)
 
     @classmethod
     def fromObject(cls, datasource):

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RRDTemplateSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RRDTemplateSpecParams.py
@@ -20,13 +20,13 @@ class RRDTemplateSpecParams(SpecParams, RRDTemplateSpec):
         self.name = name
 
         self.thresholds = self.specs_from_param(
-            RRDThresholdSpecParams, 'thresholds', thresholds, log=self.LOG)
+            RRDThresholdSpecParams, 'thresholds', thresholds, zplog=self.LOG)
 
         self.datasources = self.specs_from_param(
-            RRDDatasourceSpecParams, 'datasources', datasources, log=self.LOG)
+            RRDDatasourceSpecParams, 'datasources', datasources, zplog=self.LOG)
 
         self.graphs = self.specs_from_param(
-            GraphDefinitionSpecParams, 'graphs', graphs, log=self.LOG)
+            GraphDefinitionSpecParams, 'graphs', graphs, zplog=self.LOG)
 
     @classmethod
     def fromObject(cls, template):

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/SpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/SpecParams.py
@@ -7,17 +7,17 @@
 #
 ##############################################################################
 from ..spec.Spec import Spec
-from ..functions import LOG
+from ..helpers.ZenPackLibLog import DEFAULTLOG
 
 
 class SpecParams(object):
     """SpecParams"""
 
-    LOG = LOG
+    LOG = DEFAULTLOG
 
     def __init__(self, **kwargs):
         # Initialize with default values
-        self.LOG = kwargs.get('log', LOG)
+        self.LOG = kwargs.get('zplog', DEFAULTLOG)
 
         params = self.__class__.init_params()
         for param in params:

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
@@ -20,7 +20,7 @@ class ZenPackSpecParams(SpecParams, ZenPackSpec):
         self.name = name
 
         self.zProperties = self.specs_from_param(
-            ZPropertySpecParams, 'zProperties', zProperties, leave_defaults=True, log=self.LOG)
+            ZPropertySpecParams, 'zProperties', zProperties, leave_defaults=True, zplog=self.LOG)
 
         self.class_relationships = []
         if class_relationships:
@@ -28,13 +28,13 @@ class ZenPackSpecParams(SpecParams, ZenPackSpec):
                 raise ValueError("class_relationships must be a list, not a %s" % type(class_relationships))
 
             for rel in class_relationships:
-                rel['log'] = self.LOG
+                rel['zplog'] = self.LOG
                 self.class_relationships.append(RelationshipSchemaSpec(self, **rel))
 
         self.classes = self.specs_from_param(
-            ClassSpecParams, 'classes', classes, leave_defaults=True, log=self.LOG)
+            ClassSpecParams, 'classes', classes, leave_defaults=True, zplog=self.LOG)
 
         self.device_classes = self.specs_from_param(
-            DeviceClassSpecParams, 'device_classes', device_classes, leave_defaults=True, log=self.LOG)
+            DeviceClassSpecParams, 'device_classes', device_classes, leave_defaults=True, zplog=self.LOG)
 
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
@@ -11,12 +11,10 @@ from Products.Zuul.utils import ZuulMessageFactory as _t
 from Products.Zuul.infos import ProxyProperty
 from ..helpers.OrderAndValue import OrderAndValue
 from .Spec import Spec, MethodInfoProperty, EnumInfoProperty
-from ..functions import LOG
+
 
 class ClassPropertySpec(Spec):
     """ClassPropertySpec"""
-
-    LOG = LOG
 
     def __init__(
             self,
@@ -43,7 +41,7 @@ class ClassPropertySpec(Spec):
             datapoint_cached=True,
             index_scope='device',
             _source_location=None,
-            log=LOG
+            zplog=None,
             ):
         """
         Create a Class Property Specification
@@ -102,7 +100,8 @@ class ClassPropertySpec(Spec):
 
         """
         super(ClassPropertySpec, self).__init__(_source_location=_source_location)
-        self.LOG = log
+        if zplog:
+            self.LOG = zplog
         self.class_spec = class_spec
         self.name = name
         self.default = default

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassRelationshipSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassRelationshipSpec.py
@@ -12,13 +12,10 @@ from Products.ZenRelations.RelSchema import ToManyCont, ToOne
 
 from .Spec import Spec, RelationshipInfoProperty, RelationshipLengthProperty
 from ..helpers.OrderAndValue import OrderAndValue
-from ..functions import LOG
 
 
 class ClassRelationshipSpec(Spec):
     """ClassRelationshipSpec"""
-
-    LOG = LOG
 
     def __init__(
             self,
@@ -36,7 +33,7 @@ class ClassRelationshipSpec(Spec):
             render_with_type=False,
             order=None,
             _source_location=None,
-            log=LOG
+            zplog=None
             ):
         """
         Create a Class Relationship Specification
@@ -80,8 +77,8 @@ class ClassRelationshipSpec(Spec):
 
         """
         super(ClassRelationshipSpec, self).__init__(_source_location=_source_location)
-        self.LOG=log
-
+        if zplog:
+            self.LOG = zplog
         self.class_ = class_
         self.name = name
         self.schema = schema

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -30,7 +30,7 @@ from ..utils import impact_installed, dynamicview_installed, has_metricfacade, F
 
 from ..gsm import get_gsm
 from ..functions import pluralize, get_symbol_name, relname_from_classname, \
-    get_zenpack_path, ordered_values, LOG
+    get_zenpack_path, ordered_values
 
 from ..base.HardwareComponent import HardwareComponent
 from ..base.Component import Component
@@ -102,8 +102,6 @@ class ClassSpec(Spec):
     to double adapters doing the same thing.
     """
 
-    LOG = LOG
-
     def __init__(
             self,
             zenpack,
@@ -133,7 +131,7 @@ class ClassSpec(Spec):
             dynamicview_relations=None,
             extra_paths=None,
             _source_location=None,
-            log=LOG
+            zplog=None
             ):
         """
             Create a Class Specification
@@ -199,7 +197,8 @@ class ClassSpec(Spec):
 
         """
         super(ClassSpec, self).__init__(_source_location=_source_location)
-        self.LOG = log
+        if zplog:
+            self.LOG = zplog
         self.zenpack = zenpack
         self.name = name
 
@@ -239,11 +238,11 @@ class ClassSpec(Spec):
 
         # Properties.
         self.properties = self.specs_from_param(
-            ClassPropertySpec, 'properties', properties, log=self.LOG)
+            ClassPropertySpec, 'properties', properties, zplog=self.LOG)
 
         # Relationships.
         self.relationships = self.specs_from_param(
-            ClassRelationshipSpec, 'relationships', relationships, log=self.LOG)
+            ClassRelationshipSpec, 'relationships', relationships, zplog=self.LOG)
 
         # Impact.
         self.impacts = impacts

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
@@ -8,13 +8,10 @@
 ##############################################################################
 from .Spec import Spec
 from .RRDTemplateSpec import RRDTemplateSpec
-from ..functions import LOG
 
 
 class DeviceClassSpec(Spec):
     """Initialize a DeviceClass via Python at install time."""
-
-    LOG = LOG
 
     def __init__(
             self,
@@ -25,7 +22,7 @@ class DeviceClassSpec(Spec):
             remove=False,
             templates=None,
             _source_location=None,
-            log=LOG):
+            zplog=None):
         """
             Create a DeviceClass Specification
 
@@ -39,7 +36,8 @@ class DeviceClassSpec(Spec):
             :type templates: SpecsParameter(RRDTemplateSpec)
         """
         super(DeviceClassSpec, self).__init__(_source_location=_source_location)
-        self.LOG=log
+        if zplog:
+            self.LOG = zplog
         self.zenpack_spec = zenpack_spec
         self.path = path.lstrip('/')
         self.create = bool(create)
@@ -51,4 +49,4 @@ class DeviceClassSpec(Spec):
             self.zProperties = zProperties
 
         self.templates = self.specs_from_param(
-            RRDTemplateSpec, 'templates', templates, log=self.LOG)
+            RRDTemplateSpec, 'templates', templates, zplog=self.LOG)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphDefinitionSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphDefinitionSpec.py
@@ -9,13 +9,10 @@
 from Products.ZenModel.CommentGraphPoint import CommentGraphPoint
 from .Spec import Spec
 from .GraphPointSpec import GraphPointSpec
-from ..functions import LOG
 
 
 class GraphDefinitionSpec(Spec):
     """GraphDefinitionSpec"""
-
-    LOG = LOG
 
     def __init__(
             self,
@@ -24,6 +21,7 @@ class GraphDefinitionSpec(Spec):
             height=None,
             width=None,
             units=None,
+            log=None,
             base=None,
             miny=None,
             maxy=None,
@@ -32,7 +30,7 @@ class GraphDefinitionSpec(Spec):
             graphpoints=None,
             comments=None,
             _source_location=None,
-            log=LOG,
+            zplog=None,
             ):
         """
         Create a GraphDefinition Specification
@@ -61,7 +59,8 @@ class GraphDefinitionSpec(Spec):
         :type comments: list(str)
         """
         super(GraphDefinitionSpec, self).__init__(_source_location=_source_location)
-        self.LOG=log
+        if zplog:
+            self.LOG = zplog
         self.template_spec = template_spec
         self.name = name
 
@@ -75,7 +74,7 @@ class GraphDefinitionSpec(Spec):
         self.custom = custom
         self.hasSummary = hasSummary
         self.graphpoints = self.specs_from_param(
-            GraphPointSpec, 'graphpoints', graphpoints, log=self.LOG)
+            GraphPointSpec, 'graphpoints', graphpoints, zplog=self.LOG)
         self.comments = comments
 
         # TODO fix comments parsing - must always be a list.

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
@@ -10,7 +10,6 @@ from Products.ZenModel.GraphPoint import GraphPoint
 from Products.ZenModel.DataPointGraphPoint import DataPointGraphPoint
 from Products.ZenModel.ComplexGraphPoint import ComplexGraphPoint
 from .Spec import Spec
-from ..functions import LOG
 
 
 class GraphPointSpec(Spec):
@@ -33,7 +32,7 @@ class GraphPointSpec(Spec):
             color=None,
             includeThresholds=False,
             _source_location=None,
-            log=LOG
+            zplog=None
             ):
         """
         Create a GraphPoint Specification
@@ -65,7 +64,8 @@ class GraphPointSpec(Spec):
 
         """
         super(GraphPointSpec, self).__init__(_source_location=_source_location)
-        self.LOG=log
+        if zplog:
+            self.LOG = zplog
 
         self.template_spec = template_spec
         self.name = name

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
@@ -8,13 +8,10 @@
 ##############################################################################
 import re
 from .Spec import Spec
-from ..functions import LOG
 
 
 class RRDDatapointSpec(Spec):
     """RRDDatapointSpec"""
-
-    LOG = LOG
 
     def __init__(
             self,
@@ -30,7 +27,7 @@ class RRDDatapointSpec(Spec):
             shorthand=None,
             extra_params=None,
             _source_location=None,
-            log=LOG
+            zplog=None
             ):
         """
         Create an RRDDatapoint Specification
@@ -54,7 +51,8 @@ class RRDDatapointSpec(Spec):
 
         """
         super(RRDDatapointSpec, self).__init__(_source_location=_source_location)
-        self.LOG=log
+        if zplog:
+            self.LOG = zplog
 
         self.datasource_spec = datasource_spec
         self.name = name

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatasourceSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatasourceSpec.py
@@ -8,13 +8,9 @@
 ##############################################################################
 from .Spec import Spec
 from .RRDDatapointSpec import RRDDatapointSpec
-from ..functions import LOG
-
 
 class RRDDatasourceSpec(Spec):
     """RRDDatasourceSpec"""
-
-    LOG = LOG
 
     def __init__(
             self,
@@ -30,7 +26,7 @@ class RRDDatasourceSpec(Spec):
             datapoints=None,
             extra_params=None,
             _source_location=None,
-            log=LOG
+            zplog=None
             ):
         """
         Create an RRDDatasource Specification
@@ -57,7 +53,8 @@ class RRDDatasourceSpec(Spec):
 
         """
         super(RRDDatasourceSpec, self).__init__(_source_location=_source_location)
-        self.LOG=log
+        if zplog:
+            self.LOG = zplog
 
         self.template_spec = template_spec
         self.name = name
@@ -74,7 +71,7 @@ class RRDDatasourceSpec(Spec):
             self.extra_params = extra_params
 
         self.datapoints = self.specs_from_param(
-            RRDDatapointSpec, 'datapoints', datapoints, log=self.LOG)
+            RRDDatapointSpec, 'datapoints', datapoints, zplog=self.LOG)
 
     def create(self, templatespec, template):
         datasource_types = dict(template.getDataSourceOptions())

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -10,13 +10,10 @@ from .Spec import Spec
 from .RRDThresholdSpec import RRDThresholdSpec
 from .RRDDatasourceSpec import RRDDatasourceSpec
 from .GraphDefinitionSpec import GraphDefinitionSpec
-from ..functions import LOG
 
 
 class RRDTemplateSpec(Spec):
     """RRDTemplateSpec"""
-
-    LOG = LOG
 
     def __init__(
             self,
@@ -28,7 +25,7 @@ class RRDTemplateSpec(Spec):
             datasources=None,
             graphs=None,
             _source_location=None,
-            log=LOG
+            zplog=None
             ):
         """
         Create an RRDTemplate Specification
@@ -47,7 +44,8 @@ class RRDTemplateSpec(Spec):
 
         """
         super(RRDTemplateSpec, self).__init__(_source_location=_source_location)
-        self.LOG=log
+        if zplog:
+            self.LOG = zplog
 
         self.deviceclass_spec = deviceclass_spec
         self.name = name
@@ -55,13 +53,13 @@ class RRDTemplateSpec(Spec):
         self.targetPythonClass = targetPythonClass
 
         self.thresholds = self.specs_from_param(
-            RRDThresholdSpec, 'thresholds', thresholds, log=self.LOG)
+            RRDThresholdSpec, 'thresholds', thresholds, zplog=self.LOG)
 
         self.datasources = self.specs_from_param(
-            RRDDatasourceSpec, 'datasources', datasources, log=self.LOG)
+            RRDDatasourceSpec, 'datasources', datasources, zplog=self.LOG)
 
         self.graphs = self.specs_from_param(
-            GraphDefinitionSpec, 'graphs', graphs, log=self.LOG)
+            GraphDefinitionSpec, 'graphs', graphs, zplog=self.LOG)
 
     def create(self, dmd, addToZenPack=True):
         device_class = dmd.Devices.createOrganizer(self.deviceclass_spec.path)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDThresholdSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDThresholdSpec.py
@@ -7,13 +7,9 @@
 #
 ##############################################################################
 from .Spec import Spec
-from ..functions import LOG
-
 
 class RRDThresholdSpec(Spec):
     """RRDThresholdSpec"""
-
-    LOG = LOG
 
     def __init__(
             self,
@@ -26,7 +22,7 @@ class RRDThresholdSpec(Spec):
             enabled=None,
             extra_params=None,
             _source_location=None,
-            log=LOG
+            zplog=None
             ):
         """
         Create an RRDThreshold Specification
@@ -47,7 +43,8 @@ class RRDThresholdSpec(Spec):
 
         """
         super(RRDThresholdSpec, self).__init__(_source_location=_source_location)
-        self.LOG=log
+        if zplog:
+            self.LOG = zplog
 
         self.name = name
         self.template_spec = template_spec

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RelationshipSchemaSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RelationshipSchemaSpec.py
@@ -10,13 +10,10 @@ from Products.ZenRelations.RelSchema import ToMany, ToManyCont, ToOne
 from Products.ZenRelations.Exceptions import ZenSchemaError
 from ..functions import relname_from_classname
 from .Spec import Spec
-from ..functions import LOG
 
 
 class RelationshipSchemaSpec(Spec):
     """RelationshipSchemaSpec"""
-
-    LOG = LOG
 
     def __init__(
         self,
@@ -28,7 +25,7 @@ class RelationshipSchemaSpec(Spec):
         right_class=None,
         right_relname=None,
         _source_location=None,
-        log=LOG
+        zplog=None
     ):
         """
             Create a Relationship Schema specification.  This describes both sides
@@ -49,7 +46,8 @@ class RelationshipSchemaSpec(Spec):
 
         """
         super(RelationshipSchemaSpec, self).__init__(_source_location=_source_location)
-        self.LOG=log
+        if zplog:
+            self.LOG = zplog
 
         if not RelationshipSchemaSpec.valid_orientation(left_type, right_type):
             raise ZenSchemaError("In %s(%s) - (%s)%s, invalid orientation- left and right may be reversed." % (left_class, left_relname, right_relname, right_class))

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
@@ -8,13 +8,10 @@
 ##############################################################################
 from Products.ZenRelations.zPropertyCategory import setzPropertyCategory
 from .Spec import Spec
-from ..functions import LOG
 
 
 class ZPropertySpec(Spec):
     """ZPropertySpec"""
-
-    LOG = LOG
 
     def __init__(
             self,
@@ -24,7 +21,7 @@ class ZPropertySpec(Spec):
             default=None,
             category=None,
             _source_location=None,
-            log=LOG
+            zplog=None
             ):
         """
             Create a ZProperty Specification
@@ -38,7 +35,8 @@ class ZPropertySpec(Spec):
             :type category: str
         """
         super(ZPropertySpec, self).__init__(_source_location=_source_location)
-        self.LOG=log
+        if zplog:
+            self.LOG = zplog
 
         self.zenpack_spec = zenpack_spec
         self.name = name

--- a/ZenPacks/zenoss/ZenPackLib/lib/tests/TestCase.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/tests/TestCase.py
@@ -7,7 +7,9 @@
 #
 ##############################################################################
 import importlib
-from ..functions import LOG
+import logging
+import sys
+from ..helpers.ZenPackLibLog import DEFAULTLOG
 
 
 """Enable test mode. Only call from code under tests/.
@@ -28,13 +30,23 @@ class TestCase(BaseTestCase):
     # set disableLogging = False in your subclass.  This is
     # recommended during active development, but is too noisy
     # to leave as the default.
-    LOG = LOG
+    LOG = DEFAULTLOG
 
     disableLogging = True
 
-    def afterSetUp(self):
-        super(TestCase, self).afterSetUp()
+    def enable_log_stderr(self):
+        """
+            Enable logging to stderr 
+            using this ZenPack's log settings
+        """
+        self.LOG.propagate = False
+        h = logging.StreamHandler(sys.stderr)
+        h.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(name)s: %(message)s'))
+        self.LOG.addHandler(h)
 
+    def afterSetUp(self):
+        self.enable_log_stderr()
+        super(TestCase, self).afterSetUp()
         # Not included with BaseTestCase. Needed to test that UI
         # components have been properly registered.
         from Products.Five import zcml

--- a/ZenPacks/zenoss/ZenPackLib/lib/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/utils.py
@@ -6,8 +6,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-from .helpers.ZenPackLibLog import ZenPackLibLog
-from .functions import LOG
+from .helpers.ZenPackLibLog import DEFAULTLOG
 
 
 FACET_BLACKLIST = (
@@ -28,7 +27,7 @@ def yaml_installed():
         import yaml
         import yaml.constructor
     except ImportError:
-        LOG.critical('PyYAML is required but not installed. Run "easy_install PyYAML" or "pip install PyYAML"')
+        DEFAULTLOG.critical('PyYAML is required but not installed. Run "easy_install PyYAML" or "pip install PyYAML"')
         pass
     else:
         return True
@@ -41,7 +40,7 @@ def impact_installed():
         from ZenPacks.zenoss.Impact.impactd.relations import ImpactEdge
         from ZenPacks.zenoss.Impact.impactd.interfaces import IRelationshipDataProvider
     except ImportError:
-        LOG.info('Impact is not installed and some functionality dependent on it will be disabled')
+        DEFAULTLOG.info('Impact is not installed and some functionality dependent on it will be disabled')
         pass
     else:
         return True
@@ -55,7 +54,7 @@ def dynamicview_installed():
         from ZenPacks.zenoss.DynamicView.interfaces import IRelatable, IRelationsProvider, IGroupMappingProvider
         from ZenPacks.zenoss.DynamicView.model.adapters import BaseRelatable, BaseRelationsProvider
     except ImportError:
-        LOG.info('DynamicView is not installed and some functionality dependent on it will be disabled')
+        DEFAULTLOG.info('DynamicView is not installed and some functionality dependent on it will be disabled')
         pass
     else:
         return True
@@ -67,7 +66,7 @@ def has_metricfacade():
     try:
         from Products.Zuul.facades import metricfacade
     except ImportError:
-        LOG.info('MetricFacade is not available and some functionality dependent on it will be disabled')
+        DEFAULTLOG.info('MetricFacade is not available and some functionality dependent on it will be disabled')
         pass
     else:
         return True

--- a/ZenPacks/zenoss/ZenPackLib/lib/wrapper/ComponentFormBuilder.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/wrapper/ComponentFormBuilder.py
@@ -12,7 +12,7 @@ from zope.interface import implements, providedBy
 from Products.Zuul.form.interfaces import IFormBuilder
 from Products.Zuul.interfaces import IInfo
 from Products.Zuul.infos.component import ComponentFormBuilder as BaseComponentFormBuilder
-from ..functions import LOG
+from ..helpers.ZenPackLibLog import DEFAULTLOG
 
 
 class ComponentFormBuilder(BaseComponentFormBuilder):
@@ -25,7 +25,7 @@ class ComponentFormBuilder(BaseComponentFormBuilder):
 
     implements(IFormBuilder)
     adapts(IInfo)
-    LOG = LOG
+    LOG = DEFAULTLOG
 
     def render(self, **kwargs):
         rendered = super(ComponentFormBuilder, self).render(kwargs)


### PR DESCRIPTION
- ZenPackSpec allocates LOG class parameter to ZenPack class (removed
setting in __init__ (fixes installation issue)
- GraphPointSpec 'log' graph property (logarithm) was being overridden
by "log" logger instance, which prevents ZP installation from completing
correctly
- ZenPack.py now logs to stderr by default (during installation) with
verbosity settings in load_yaml()
- added stderr logging for TestCase and ZPLCommand classes
- changed 'log' argument to 'zplog' throughout
- classes should revert to default log if none specified
- removed unneeded imports
- fix string formatting in ZenPack.py
- move import of DEFAULTLOG from functions.py to helpers.ZenPackLog.py