### PR TITLE
Prevent errors with ZPL class overrides

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -331,17 +331,23 @@ class ClassSpec(Spec):
 
     def create(self):
         """Implement specification."""
+        self.create_schema_classes()
+        self.create_zenpack_classes()
+        self.create_registered()
+
+    def create_schema_classes(self):
         self.create_model_schema_class()
         self.create_iinfo_schema_class()
         self.create_info_schema_class()
 
+    def create_zenpack_classes(self):
         self.create_model_class()
         self.create_iinfo_class()
         self.create_info_class()
-
         if self.is_component or self.is_hardware_component:
             self.create_formbuilder_class()
 
+    def create_registered(self):
         self.register_dynamicview_adapters()
         self.register_impact_adapters()
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
@@ -273,8 +273,14 @@ class ZenPackSpec(Spec):
         for spec in self.zProperties.itervalues():
             spec.create()
 
+        # try to avoid import errors on class overrides
+        # by creating specs first
         for spec in self.classes.itervalues():
-            spec.create()
+            spec.create_schema_classes()
+
+        for spec in self.classes.itervalues():
+            spec.create_zenpack_classes()
+            spec.create_registered()
 
         self.create_product_names()
         self.create_ordered_component_tree()


### PR DESCRIPTION
- Fixes issue using ZPL ZenPack with vSphere ZenPack
- Create all initial "schema" classes before creating dependent ZP
classes