### PR TITLE
Ensure catalog creation respects spec property indexes (ZEN-18629)

### DIFF
--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -510,7 +510,13 @@ class CatalogBase(object):
         if not spec:
             []
 
-        scopes = [spec['indexes'][x].get('scope', 'device') for x in spec['indexes']]
+        indexes = spec.get('indexes',{})
+        scopes = [indexes[x].get('scope', 'device') for x in indexes]
+        if name != 'ComponentBase':
+            # ignore the id index if not ComponentBaseSearch and if other indexes exist
+            if 'id' in indexes and len(indexes.keys()) > 1:
+                scopes = [indexes[x].get('scope', 'device') for x in indexes if x != 'id']
+
         if 'both' in scopes:
             scopes = [x for x in scopes if x != 'both']
             scopes.append('device')


### PR DESCRIPTION
- Fixes ZEN-18269
- Revise get_catalog_scopes() to ignore the 'id' index if catalog is
other than "BaseComponentSearch" and if other indexes are defined