### PR TITLE
Simplify load_yaml() call

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
@@ -55,6 +55,8 @@ def load_yaml(yaml_doc=None, verbose=False, level=0):
             DEFAULTLOG.error("YAML load error %s" % e)
     # loading from multiple files
     if isinstance(yaml_doc, list):
+        if len(yaml_doc) == 1:
+            return load_yaml(yaml_doc[0], verbose, level)
         # build python dict of merged YAML data
         cfg_data = {}
         # this is to make sure ZP names don't conflict

--- a/ZenPacks/zenoss/ZenPackLib/lib/wrapper/ComponentFormBuilder.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/wrapper/ComponentFormBuilder.py
@@ -72,7 +72,7 @@ class ComponentFormBuilder(BaseComponentFormBuilder):
                 c = self._dict(v)
                 c['name'] = k
                 value =  getattr(self.context, k, None)
-                c['value'] = value() if callable(value) else value                    
+                c['value'] = value() if callable(value) else value
                 if c['xtype'] in ('autoformcombo', 'itemselector'):
                     c['values'] = self.vocabulary(v)
                 d[k] = c


### PR DESCRIPTION
- Simplify most common case where load_yam() is called without supplied
yaml_doc parameter
- Removed EOL spaces in ComponentFormBuilder