### PR TITLE
Support adding devtypes (ZEN-22366)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -55,6 +55,19 @@ class ZenPack(ZenPackBase):
                 self.LOG.info('Setting zProperty {} on {}'.format(zprop, dcspec.path))
                 dcObject.setZenProperty(zprop, value)
 
+            # if device class has description and protocol, register a devtype
+            if dcspec.description and dcspec.protocol:
+                try:
+                    if (dcspec.description, dcspec.protocol) not in dcObject.devtypes:
+                        self.LOG.info('Registering devtype for {}: {} ({})'.format(dcObject,
+                                                                                   dcspec.protocol,
+                                                                                   dcspec.description))
+                        dcObject.register_devtype(dcspec.description, dcspec.protocol)
+                except Exception as e:
+                    self.LOG.warn('Error registering devtype for {}: {} ({})'.format(dcObject,
+                                                                                     dcspec.protocol,
+                                                                                     e))
+
         # Load objects.xml now
         super(ZenPack, self).install(app)
         if self.NEW_COMPONENT_TYPES:

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
@@ -21,6 +21,8 @@ class DeviceClassSpec(Spec):
             zProperties=None,
             remove=False,
             templates=None,
+            description=None,
+            protocol=None,
             _source_location=None,
             zplog=None):
         """
@@ -34,6 +36,12 @@ class DeviceClassSpec(Spec):
             :type zProperties: dict(str)
             :param templates: TODO
             :type templates: SpecsParameter(RRDTemplateSpec)
+            :param description: Description used for registering devtype
+            :type description: str
+            :param description: Description used for registering devtype
+            :type description: str
+            :param protocol: Protocol to use for registered devtype
+            :type protocol: str
         """
         super(DeviceClassSpec, self).__init__(_source_location=_source_location)
         if zplog:
@@ -42,6 +50,8 @@ class DeviceClassSpec(Spec):
         self.path = path.lstrip('/')
         self.create = bool(create)
         self.remove = bool(remove)
+        self.description = description
+        self.protocol = protocol
 
         if zProperties is None:
             self.zProperties = {}


### PR DESCRIPTION
- Add support for "devtypes" (multi-device GUI addition)
- Fixes ZEN-22366
- Added "description" and "protocol" attributes to DeviceClassSpec
- Updated ZenPack install method to register devtypes if supplied
description and protocol.