### PR TITLE
Fix execution and argument handling of $ZENHOME/bin/zenpacklib

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/__init__.py
+++ b/ZenPacks/zenoss/ZenPackLib/__init__.py
@@ -28,6 +28,7 @@ class ZenPack(ZenPackBase):
     def install(self, dmd):
         if yaml_installed():
             ZenPackBase.install(self, dmd)
+            self.check_permissions()
             self.create_symlink()
         else:
             sys.exit(1)
@@ -38,6 +39,13 @@ class ZenPack(ZenPackBase):
             pass
         self.remove_symlink()
         ZenPackBase.remove(self, dmd, leaveObjects=leaveObjects)
+
+    def check_permissions(self):
+        basedir = os.path.dirname(__file__)
+        shell_path = os.path.join(basedir, "bin/zenpacklib")
+        py_path = os.path.join(basedir, 'zenpacklib.py')
+        for x in [shell_path, py_path]:
+            os.chmod(x, 0755)
 
     def create_symlink(self):
         '''create symlink'''

--- a/ZenPacks/zenoss/ZenPackLib/bin/zenpacklib
+++ b/ZenPacks/zenoss/ZenPackLib/bin/zenpacklib
@@ -9,11 +9,9 @@
 ##############################################################################
 
 
-. $ZENHOME/bin/zenfunctions
-
 MYPATH=`python -c "import os.path; print os.path.realpath('$0')"`
 THISDIR=`dirname $MYPATH`
 PRGHOME=`dirname $THISDIR`
 PRGNAME=zenpacklib.py
 
-python $PRGHOME/$PRGNAME $@
+python $PRGHOME/$PRGNAME "$@"


### PR DESCRIPTION
- $ZENHOME/bin/zenpacklib handles zenpacklib.py parameters correctly
- updated ZenPack install method to set executable permissions on
included bin/zenpacklib and zenpacklib.py