### PR TITLE
Increased accuracy of template modification detection

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatapointSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatapointSpecParams.py
@@ -89,6 +89,10 @@ class RRDDatapointSpecParams(SpecParams, RRDDatapointSpec):
                 io.close()
 
                 io = StringIO.StringIO()
+                # these won't get set on the sample dp
+                sample_dp.aliases = datapoint.aliases
+                sample_dp._zendoc = datapoint._zendoc
+
                 sample_dp.exportXml(io)
                 sample_dp_xml = io.getvalue()
                 io.close()

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
@@ -121,7 +121,7 @@ class ZenPackSpec(Spec):
             zProperties=zProperties,
             classes=classes,
             class_relationships=class_relationships,
-            device_classes=device_classes, 
+            device_classes=device_classes,
             zplog=self.LOG)
         self.name = name
         self.LOG.debug("------ {} ------".format(self.name))
@@ -145,7 +145,7 @@ class ZenPackSpec(Spec):
 
         # Classes
         self.classes = self.specs_from_param(ClassSpec, 'classes', classes, zplog=self.LOG)
-        
+
         self.imported_classes = {}
 
         # Import any external classes referred to in the schema
@@ -583,7 +583,6 @@ class ZenPackSpec(Spec):
                             'ZenPack',
                             (ZenPack,),
                             attributes)
-        cls.LOG = self.LOG
         return cls
 
     def test_setup(self):

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/hp_proliant.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/hp_proliant.yaml
@@ -1,4 +1,4 @@
-name: ZenPacks.zenoss.ZenPackLib
+name: ZenPacks.zenoss.HP.ZenPackLib
 zProperties:
   DEFAULTS:
     category: ILO
@@ -1915,7 +1915,7 @@ device_classes:
           status:
             type: ILO
             component: ${here/id}
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             ilo_query: <SERVER_INFO MODE=\"read\"><GET_EMBEDDED_HEALTH/></SERVER_INFO>
             ilo_result_key: HEALTH_AT_A_GLANCE
@@ -1936,7 +1936,7 @@ device_classes:
           DEFAULTS:
             type: ILO
             component: ${here/id}
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             ilo_query: <SERVER_INFO MODE=\"read\"><GET_EMBEDDED_HEALTH/></SERVER_INFO>
             ilo_result_key: HEALTH_AT_A_GLANCE
@@ -1977,7 +1977,7 @@ device_classes:
           DEFAULTS:
             type: ILO
             component: ${here/id}
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             ilo_query: <SERVER_INFO MODE=\"read\"><GET_EMBEDDED_HEALTH/></SERVER_INFO>
             ilo_result_key: HEALTH_AT_A_GLANCE
@@ -2011,7 +2011,7 @@ device_classes:
           condition:
             type: ILO
             component: ${here/id}
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             ilo_query: <SERVER_INFO MODE=\"read\"><GET_EMBEDDED_HEALTH/></SERVER_INFO>
             ilo_result_key: LOGICAL_DRIVE
@@ -2032,7 +2032,7 @@ device_classes:
           status:
             type: ILO
             component: ${here/id}
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             ilo_query: <SERVER_INFO MODE=\"read\"><GET_EMBEDDED_HEALTH/></SERVER_INFO>
             ilo_result_key: HEALTH_AT_A_GLANCE
@@ -2053,7 +2053,7 @@ device_classes:
           status:
             type: ILO
             component: ${here/id}
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             ilo_query: <SERVER_INFO MODE=\"read\"><GET_EMBEDDED_HEALTH/></SERVER_INFO>
             ilo_result_key: CPU_${here/cpuNum}
@@ -2074,7 +2074,7 @@ device_classes:
           status:
             type: ILO
             component: ${here/id}
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             datapoints:
               status:
@@ -2095,7 +2095,7 @@ device_classes:
           status:
             type: ILO
             component: ${here/id}
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             ilo_query: <SERVER_INFO MODE=\"read\"><GET_EMBEDDED_HEALTH/></SERVER_INFO>
             ilo_result_key: PHYSICAL_DRIVE
@@ -2116,7 +2116,7 @@ device_classes:
           status:
             type: ILO
             component: ${here/id}
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             ilo_query: <SERVER_INFO MODE=\"read\"><GET_EMBEDDED_HEALTH/></SERVER_INFO>
             ilo_result_key: PROCESSOR
@@ -2136,7 +2136,7 @@ device_classes:
         datasources:
           status:
             type: ILO
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             ilo_query: <SERVER_INFO MODE=\"read\"><GET_EMBEDDED_HEALTH/></SERVER_INFO>
             ilo_result_key: SUPPLY
@@ -2161,7 +2161,7 @@ device_classes:
           DEFAULTS:
             type: ILO
             component: ${here/id}
-            cycletime: 300
+            cycletime: '300'
             timeout_delay: 60
             ilo_query: <SERVER_INFO MODE=\"read\"><GET_EMBEDDED_HEALTH/></SERVER_INFO>
             ilo_result_key: TEMP
@@ -2609,7 +2609,7 @@ device_classes:
         datasources:
           status:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               status: GAUGE
             namespace: root/hpq
@@ -2632,7 +2632,7 @@ device_classes:
         datasources:
           speed:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               speed: GAUGE
             namespace: root/hpq
@@ -2641,7 +2641,7 @@ device_classes:
             result_component_value: ${here/fanName}
           status:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               status: GAUGE
             namespace: root/hpq
@@ -2669,7 +2669,7 @@ device_classes:
         datasources:
           status:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               status: GAUGE
             namespace: root/hpq
@@ -2687,7 +2687,7 @@ device_classes:
         datasources:
           status:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               status: GAUGE
             namespace: root/hpq
@@ -2705,7 +2705,7 @@ device_classes:
         datasources:
           status:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               status: GAUGE
             namespace: root/hpq
@@ -2727,7 +2727,7 @@ device_classes:
         datasources:
           status:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               status: GAUGE
             namespace: root/hpq
@@ -2736,7 +2736,7 @@ device_classes:
             result_component_value: ${here/id}
           bytesReceived:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               bytesReceived:
                 rrdtype: DERIVE
@@ -2746,7 +2746,7 @@ device_classes:
             result_component_value: ${here/id}
           bytesTransmitted:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               bytesTransmitted:
                 rrdtype: DERIVE
@@ -2756,7 +2756,7 @@ device_classes:
             result_component_value: ${here/id}
           packetsReceived:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               packetsReceived:
                 rrdtype: DERIVE
@@ -2767,7 +2767,7 @@ device_classes:
             result_component_value: ${here/id}
           packetsTransmitted:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               packetsTransmitted:
                 rrdtype: DERIVE
@@ -2778,7 +2778,7 @@ device_classes:
             result_component_value: ${here/id}
           receiveErrors:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               receiveErrors:
                 rrdtype: DERIVE
@@ -2788,7 +2788,7 @@ device_classes:
             result_component_value: ${here/id}
           transmitErrors:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               transmitErrors:
                 rrdtype: DERIVE
@@ -2843,7 +2843,7 @@ device_classes:
         datasources:
           status:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               status: GAUGE
             namespace: root/hpq
@@ -2861,7 +2861,7 @@ device_classes:
         datasources:
           status:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               status: GAUGE
             namespace: root/hpq
@@ -2882,7 +2882,7 @@ device_classes:
         datasources:
           currentReading:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               currentReading: GAUGE
             namespace: root/hpq
@@ -2891,7 +2891,7 @@ device_classes:
             result_component_value: ${here/id}
           status:
             type: WBEM
-            cycletime: 300
+            cycletime: '300'
             datapoints:
               status: GAUGE
             namespace: root/hpq

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    Test accurate detection of template modifications
+"""
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+
+# stdlib Imports
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+# zenpacklib Imports
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
+from ZenPacks.zenoss.ZenPackLib.lib.base.ZenPack import ZenPack
+from ZenPacks.zenoss.ZenPackLib.lib.params.RRDTemplateSpecParams import RRDTemplateSpecParams
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Dumper import Dumper
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Loader import Loader
+
+
+YAML_DOC = """name: ZenPacks.zenoss.ZenPackLib
+device_classes:
+  /Server:
+    templates:
+      Device:
+        description: Net-SNMP template for late vintage unix device.  Has CPU threshold.
+        thresholds:
+          CPU Utilization:
+            dsnames: [ssCpuRawIdle_ssCpuRawIdle]
+            eventClass: /Perf/CPU
+            minval: '2'
+            escalateCount: 5
+        datasources:
+          memBuffer:
+            type: SNMP
+            datapoints:
+              memBuffer:
+                aliases: {memoryBuffered__bytes: '1024,*'}
+            oid: .1.3.6.1.4.1.2021.4.14.0
+          laLoadInt5:
+            type: SNMP
+            datapoints:
+              laLoadInt5:
+                aliases: {loadAverage5min: '100,/'}
+            oid: 1.3.6.1.4.1.2021.10.1.5.2
+          ssCpuRawIdle:
+            type: SNMP
+            datapoints:
+              ssCpuRawIdle:
+                rrdtype: DERIVE
+                rrdmin: 0
+                aliases: {cpu__pct: '__EVAL:str(len(here.hw.cpus())) + '',/,100,EXC,-,0,MAX'''}
+            oid: 1.3.6.1.4.1.2021.11.53.0
+          ssCpuRawSystem:
+            type: SNMP
+            datapoints:
+              ssCpuRawSystem: DERIVE_MIN_0
+            oid: 1.3.6.1.4.1.2021.11.52.0
+          ssCpuRawWait:
+            type: SNMP
+            datapoints:
+              ssCpuRawWait: DERIVE_MIN_0
+            oid: 1.3.6.1.4.1.2021.11.54.0
+          sysUpTime:
+            type: SNMP
+            datapoints:
+              sysUpTime: GAUGE
+            oid: 1.3.6.1.2.1.25.1.1.0
+          memAvailSwap:
+            type: SNMP
+            datapoints:
+              memAvailSwap: GAUGE
+            oid: 1.3.6.1.4.1.2021.4.4.0
+          memCached:
+            type: SNMP
+            datapoints:
+              memCached:
+                aliases: {memoryCached__bytes: '1024,*'}
+            oid: .1.3.6.1.4.1.2021.4.15.0
+          memAvailReal:
+            type: SNMP
+            datapoints:
+              memAvailReal:
+                aliases: {memoryAvailable__bytes: '1024,*'}
+            oid: 1.3.6.1.4.1.2021.4.6.0
+          ssCpuRawUser:
+            type: SNMP
+            datapoints:
+              ssCpuRawUser: DERIVE_MIN_0
+            oid: 1.3.6.1.4.1.2021.11.50.0
+        graphs:
+          Load Average 5 min:
+            units: processes
+            graphpoints:
+              laLoadInt5:
+                dpName: laLoadInt5_laLoadInt5
+                lineType: AREA
+                format: '%0.2lf'
+                rpn: 100,/
+          Free Memory:
+            units: bytes
+            miny: 0
+            graphpoints:
+              memAvailReal:
+                dpName: memAvailReal_memAvailReal
+                lineType: AREA
+                rpn: 1024,*
+          CPU Idle:
+            units: percentage
+            graphpoints:
+              ssCpuRawIdle:
+                dpName: ssCpuRawIdle_ssCpuRawIdle
+                lineType: AREA
+                format: '%0.1lf%%'
+                includeThresholds: true
+          Free Swap:
+            units: KBytes
+            miny: 0
+            graphpoints:
+              memAvailSwap:
+                dpName: memAvailSwap_memAvailSwap
+                lineType: AREA
+                format: '%0.2lf'
+          CPU Utilization:
+            units: percentage
+            graphpoints:
+              ssCpuRawSystem:
+                dpName: ssCpuRawSystem_ssCpuRawSystem
+                lineType: AREA
+                stacked: true
+                format: '%0.1lf%%'
+              ssCpuRawWait:
+                dpName: ssCpuRawWait_ssCpuRawWait
+                lineType: AREA
+                stacked: true
+                format: '%0.1lf%%'
+              ssCpuRawUser:
+                dpName: ssCpuRawUser_ssCpuRawUser
+                lineType: AREA
+                stacked: true
+                format: '%0.1lf%%'
+          Load Average:
+            units: load
+            graphpoints:
+              laLoadInt5:
+                dpName: laLoadInt5_laLoadInt5
+                lineType: AREA
+                format: '%0.2lf'
+                rpn: 100,/
+"""
+
+YAML_CHANGED = """name: ZenPacks.zenoss.ZenPackLib
+device_classes:
+  /Server:
+    templates:
+      Device:
+        description: Net-SNMP template for late vintage unix device.  Has CPU threshold.
+        thresholds:
+          CPU Utilization:
+            dsnames: [ssCpuRawIdle_ssCpuRawIdle]
+            eventClass: /Perf/CPU
+            minval: '3'
+            escalateCount: 7
+        datasources:
+          memBuffer:
+            type: SNMP
+            datapoints:
+              memBuffer:
+                aliases: {memoryBuffered__bytes: '1024,*'}
+            oid: .1.3.6.1.4.1.2021.4.14.0
+          laLoadInt5:
+            type: SNMP
+            datapoints:
+              laLoadInt5:
+                aliases: {loadAverage5min: '100,/'}
+            oid: 1.3.6.1.4.1.2021.10.1.5.2
+          ssCpuRawIdle:
+            type: SNMP
+            datapoints:
+              ssCpuRawIdle:
+                rrdtype: DERIVE
+                rrdmin: 0
+                aliases: {cpu__pct: '__EVAL:str(len(here.hw.cpus())) + '',/,100,EXC,-,0,MAX'''}
+            oid: 1.3.6.1.4.1.2021.11.53.0
+          ssCpuRawSystem:
+            type: SNMP
+            datapoints:
+              ssCpuRawSystem: DERIVE_MIN_0
+            oid: 1.3.6.1.4.1.2021.11.52.0
+          ssCpuRawWait:
+            type: SNMP
+            datapoints:
+              ssCpuRawWait: DERIVE_MIN_0
+            oid: 1.3.6.1.4.1.2021.11.54.0
+          sysUpTime:
+            type: SNMP
+            datapoints:
+              sysUpTime: GAUGE
+            oid: 1.3.6.1.2.1.25.1.1.0
+          memAvailSwap:
+            type: SNMP
+            datapoints:
+              memAvailSwap: GAUGE
+            oid: 1.3.6.1.4.1.2021.4.4.0
+          memCached:
+            type: SNMP
+            datapoints:
+              memCached:
+                aliases: {memoryCached__bytes: '1024,*'}
+            oid: .1.3.6.1.4.1.2021.4.15.0
+          memAvailReal:
+            type: SNMP
+            datapoints:
+              memAvailReal:
+                aliases: {memoryAvailable__bytes: '1024,*'}
+            oid: 1.3.6.1.4.1.2021.4.6.0
+          ssCpuRawUser:
+            type: SNMP
+            datapoints:
+              ssCpuRawUser: DERIVE_MIN_0
+            oid: 1.3.6.1.4.1.2021.11.50.0
+        graphs:
+          Load Average 5 min:
+            units: processes
+            graphpoints:
+              laLoadInt5:
+                dpName: laLoadInt5_laLoadInt5
+                lineType: AREA
+                format: '%0.2lf'
+                rpn: 100,/
+          Free Memory:
+            units: bytes
+            miny: 0
+            graphpoints:
+              memAvailReal:
+                dpName: memAvailReal_memAvailReal
+                lineType: AREA
+                rpn: 1024,*
+          CPU Idle:
+            units: percentage
+            graphpoints:
+              ssCpuRawIdle:
+                dpName: ssCpuRawIdle_ssCpuRawIdle
+                lineType: AREA
+                format: '%0.1lf%%'
+                includeThresholds: true
+          Free Swap:
+            units: KBytes
+            miny: 0
+            graphpoints:
+              memAvailSwap:
+                dpName: memAvailSwap_memAvailSwap
+                lineType: AREA
+                format: '%0.2lf'
+          CPU Utilization:
+            units: percentage
+            graphpoints:
+              ssCpuRawSystem:
+                dpName: ssCpuRawSystem_ssCpuRawSystem
+                lineType: AREA
+                stacked: true
+                format: '%0.1lf%%'
+              ssCpuRawWait:
+                dpName: ssCpuRawWait_ssCpuRawWait
+                lineType: AREA
+                stacked: true
+                format: '%0.1lf%%'
+              ssCpuRawUser:
+                dpName: ssCpuRawUser_ssCpuRawUser
+                lineType: AREA
+                stacked: true
+                format: '%0.1lf%%'
+          Load Average:
+            units: load
+            graphpoints:
+              laLoadInt5:
+                dpName: laLoadInt5_laLoadInt5
+                format: '%0.2lf'
+                rpn: 100,/
+"""
+
+DIFF = "--- \n+++ \n@@ -4,8 +4,8 @@\n   CPU Utilization:\n     dsnames: [ssCpuRawIdle_ssCpuRawIdle]\n     eventClass: /Perf/CPU\n-    minval: '2'\n-    escalateCount: 5\n+    minval: '3'\n+    escalateCount: 7\n datasources:\n   memBuffer:\n     type: SNMP\n@@ -113,7 +113,6 @@\n     graphpoints:\n       laLoadInt5:\n         dpName: laLoadInt5_laLoadInt5\n-        lineType: AREA\n         format: '%0.2lf'\n         rpn: 100,/\n \n"
+
+class TestTemplateModified(BaseTestCase):
+    """
+    Test installed vs spec template changes
+    """
+
+    def test_modified(self):
+        self.get_result(YAML_DOC)
+        self.get_result(YAML_CHANGED, DIFF)
+
+    def get_result(self, yaml_doc, expected=None):
+        z = ZPLTestHarness(yaml_doc)
+        z.connect()
+        zenpack = ZenPack(z.dmd)
+        deviceclass = z.dmd.Devices.getOrganizer('Server')
+        template = deviceclass.rrdTemplates._getOb('Device')
+        dcspec = z.cfg.device_classes.get('/Server')
+        tspec = dcspec.templates.get('Device')
+        diff = zenpack.template_changed(z, template, tspec)
+        self.assertEquals(diff, expected, 'Expected:\n{}\ngot:\n{}'.format(expected, diff))
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestTemplateModified))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()


### PR DESCRIPTION
- added template_changed method to ZenPack.py
- method facilitates better comparison between existing and spec-based
template
- updated ZenPack.py to use DEFAULTLOG instead of self.LOG, since log
messages weren't consistently reporting otherwise
- updated RRDDatapointSpecParams to include aliases and _zendoc when
generating comparison xml
- added test_template_modify unit test