### PR TITLE
Support setting datapoint alias as string (ZEN-19486)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
@@ -72,8 +72,11 @@ class RRDDatapointSpec(Spec):
             self.aliases = {}
         elif isinstance(aliases, dict):
             self.aliases = aliases
+        elif isinstance(aliases, str):
+            self.LOG.debug('setting default alias for {}'.format(aliases))
+            self.aliases = {aliases: None}
         else:
-            raise ValueError("aliases must be specified as a dict")
+            raise ValueError("aliases must be specified as a dict or string (got {})".format(aliases))
         self.shorthand = shorthand
         if self.shorthand:
             if 'DERIVE' in shorthand.upper():

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_zen_19486.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_zen_19486.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+""" 
+    Test fix for ZEN-19486
+    not entering dict of aliases in datapoint results in broken zenpack
+"""
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+# stdlib Imports
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+# zenpacklib Imports
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
+
+
+YAML_DOC = """name: ZenPacks.zenoss.ZenPackLib
+device_classes:
+  /Server:
+    templates:
+      Device:
+        datasources:
+          laLoadInt5:
+            type: SNMP
+            datapoints:
+              laLoadInt5:
+                aliases: {loadAverage5min: null}
+            oid: 1.3.6.1.4.1.2021.10.1.5.2
+"""
+
+BAD_DOC = """name: ZenPacks.zenoss.ZenPackLib
+device_classes:
+  /Server:
+    templates:
+      Device:
+        datasources:
+          laLoadInt5:
+            type: SNMP
+            datapoints:
+              laLoadInt5:
+                aliases: loadAverage5min
+            oid: 1.3.6.1.4.1.2021.10.1.5.2
+"""
+
+class Test19486(BaseTestCase):
+    """Test fix for ZEN-19486"""
+
+    def test_datapoint_aliases(self):
+        ''''''
+        dp_dict = self.get_alias(YAML_DOC)
+        dp_str = self.get_alias(BAD_DOC)
+        self.assertEqual(dp_dict.aliases, dp_str.aliases, 'Datapoint aliases {} and {} do not match'.format(
+                                                        dp_dict.aliases, dp_str.aliases))
+
+    def get_alias(self, yaml_doc):
+        z = ZPLTestHarness(yaml_doc)
+        dcspec = z.cfg.device_classes.get('/Server')
+        tspec = dcspec.templates.get('Device')
+        return tspec.datasources.get('laLoadInt5').datapoints.get('laLoadInt5')
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(Test19486))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()


### PR DESCRIPTION
- Fixes ZEN-19486
- when aliases is set as a string in YAML, add a dictionary to the
RRDDatapointSpec for the entry.
- added test_zen_19486 unit test