### PR TITLE
Fix Unit Tests failure (ZEN-25638)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/hp_proliant.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/hp_proliant.yaml
@@ -1,4 +1,4 @@
-name: ZenPacks.zenoss.HP.ZenPackLib
+name: ZenPacks.zenoss.ZenPackLib
 zProperties:
   DEFAULTS:
     category: ILO

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/openstack.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/openstack.yaml
@@ -1,5 +1,5 @@
 name: ZenPacks.zenoss.ZenPackLib
-zProperties: !ZenPackSpec
+zProperties:
   DEFAULTS:
     category: OpenStack
   zOpenStackCeilometerUrl: {}
@@ -78,7 +78,7 @@ class_relationships:
 - VolType 1:M Volume
 # release 2.2.0 does not do backup
 #- Volume 1:M Backup
-device_classes: !ZenPackSpec
+device_classes: 
   /Server/SSH/Linux/NovaHost:
     remove: True
     zProperties:
@@ -659,7 +659,7 @@ device_classes: !ZenPackSpec
                 dpName: networkOutgoingPacketsRate_networkOutgoingPacketsRate
                 format: '%7.2lf%s'
                 color: 98df8a
-classes: !ZenPackSpec
+classes: 
   #-----------------------------------------------------------------------------
   # Base Device Class Types
   #-----------------------------------------------------------------------------

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_classes.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_classes.py
@@ -49,7 +49,7 @@ class TestClasses(BaseTestCase):
                 self.assertTrue(zp.check_templates_vs_yaml(), "Template (YAML) testing failed for {}".format(zp.filename))
                 self.assertTrue(zp.check_templates_vs_specs(), "Template (Spec) testing failed for {}".format(zp.filename))
             except Exception as e:
-                print 'Could not test {} ({})'.format(file, e)
+                print 'Skipping test {} ({})'.format(file, e)
 
 
 def test_suite():

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
@@ -298,18 +298,22 @@ class TestTemplateModified(BaseTestCase):
     """
 
     def test_modified(self):
-        self.get_result(YAML_DOC)
-        self.get_result(YAML_CHANGED, DIFF)
+        self.get_result(YAML_DOC, YAML_DOC)
+        self.get_result(YAML_DOC, YAML_CHANGED, DIFF)
 
-    def get_result(self, yaml_doc, expected=None):
-        z = ZPLTestHarness(yaml_doc)
-        z.connect()
-        zenpack = ZenPack(z.dmd)
-        deviceclass = z.dmd.Devices.getOrganizer('Server')
-        template = deviceclass.rrdTemplates._getOb('Device')
-        dcspec = z.cfg.device_classes.get('/Server')
-        tspec = dcspec.templates.get('Device')
-        diff = zenpack.template_changed(z, template, tspec)
+    def get_result(self, orig_doc, new_doc, expected=None):
+        z_orig = ZPLTestHarness(orig_doc)
+        z_new = ZPLTestHarness(new_doc)
+        z_orig.connect()
+        z_new.connect()
+        zenpack = ZenPack(z_new.dmd)
+        # original template spec
+        orig_tspec = z_orig.cfg.device_classes.get('/Server').templates.get('Device')
+        # template based on original spec
+        orig_template = orig_tspec.create(z_orig.dmd, False)
+        # new temlate spec
+        new_tspec = z_new.cfg.device_classes.get('/Server').templates.get('Device')
+        diff = zenpack.template_changed(z_new, orig_template, new_tspec)
         self.assertEquals(diff, expected, 'Expected:\n{}\ngot:\n{}'.format(expected, diff))
 
 


### PR DESCRIPTION
- Fixes ZEN-25638
- fixed errors in hp_proliant.yaml and openstack.yaml
- updated verbiage in test_classes
- updated test_template_modify to be platform version independent