### PR TITLE
Ensure that datapoint alias keys do not exceed 31 chars (ZEN-17950)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -56,6 +56,7 @@ Fixes
 * getRRDTemplateName can return label of base class (ZEN-19025)
 * Ensure catalog creation respects spec property indexes (ZEN-18269)
 * Ensure device classes can be removed properly (ZEN-18134)
+* Ensure that datapoint alias keys do not exceed 31 chars (ZEN-17950)
 * Log obscure error with ill-defined relationships (ZEN-16701)
 
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
@@ -68,15 +68,8 @@ class RRDDatapointSpec(Spec):
         elif isinstance(extra_params, dict):
             self.extra_params = extra_params
 
-        if aliases is None:
-            self.aliases = {}
-        elif isinstance(aliases, dict):
-            self.aliases = aliases
-        elif isinstance(aliases, str):
-            self.LOG.debug('setting default alias for {}'.format(aliases))
-            self.aliases = {aliases: None}
-        else:
-            raise ValueError("aliases must be specified as a dict or string (got {})".format(aliases))
+        self.aliases = aliases
+
         self.shorthand = shorthand
         # update local variables from shorthand
         if self.shorthand:
@@ -113,6 +106,29 @@ class RRDDatapointSpec(Spec):
             return super(RRDDatapointSpec, self).__eq__(other, ignore_params=['rrdtype', 'rrdmin', 'rrdmax'])
         else:
             return super(RRDDatapointSpec, self).__eq__(other)
+
+    @property
+    def aliases(self):
+        return self._aliases
+
+    @aliases.setter
+    def aliases(self, value):
+        if value is None:
+            self._aliases = {}
+        elif isinstance(value, dict):
+            self._aliases = value
+        elif isinstance(value, str):
+            self.LOG.debug('setting default alias for {}'.format(value))
+            self._aliases = {value: None}
+        else:
+            raise ValueError("aliases must be specified as a dict or string (got {})".format(value))
+        # ensure that alias keys do not exceed 31 characters in length
+        aliases = {}
+        for k, v, in self._aliases.items():
+            if len(k) > 31:
+                self.LOG.warning("alias character length limit exceeded 31: {}, truncating".format(k))
+            aliases[k[:31]] = v
+        self._aliases = aliases
 
     @property
     def rrdtype(self):

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_zen_17950.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_zen_17950.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+""" 
+    Test fix for ZEN-17950
+    Enforce alias length limit in ZenPackLib
+"""
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+# stdlib Imports
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+# zenpacklib Imports
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
+
+
+YAML_DOC = """name: ZenPacks.zenoss.ZenPackLib
+device_classes:
+  /Server:
+    templates:
+      TEST:
+        datasources:
+          dsname:
+            type: SNMP
+            datapoints:
+              dpname26:
+                aliases: {abcdefghijklmnopqrstuvwxyz: null}
+              dpname52:
+                aliases: {abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz: null}
+              dpname26str:
+                aliases: abcdefghijklmnopqrstuvwxyz
+              dpname52str:
+                aliases: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+            oid: 1.3.6.1.4.1.2021.10.1.5.2
+"""
+
+
+class Test17950(BaseTestCase):
+    """Test fix for ZEN-17950"""
+
+    def test_datapoint_alias_length(self):
+        ''''''
+        z = ZPLTestHarness(YAML_DOC)
+        ds_spec = z.cfg.device_classes.get('/Server').templates.get('TEST').datasources.get('dsname')
+        for dp_name, dp_spec in ds_spec.datapoints.items():
+            for k in dp_spec.aliases.keys():
+                self.assertTrue(len(k) <= 31, 'Datapoint alias key too long: {} ({})'.format(k, len(k)))
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(Test17950))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()


### PR DESCRIPTION
- Fixes ZEN-19750
- If 31 character lenght exceeded, alias key is truncated and a warning
is logged
- Added test_zen_17950 unit test