### PR TITLE
Only run certain unit tests if ZenPack dependencies are satisfied (ZEN-25690)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/tests/test_zen_24083.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_zen_24083.py
@@ -24,8 +24,17 @@ from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
 
 
+def aggregator_installed():
+    """Return True if AggregatingDataSource is installed"""
+    try:
+        from ZenPacks.zenoss.CalculatedPerformance.datasources.AggregatingDataSource import AggregatingDataSource
+    except ImportError:
+        pass
+    else:
+        return True
+    return False
 
-YAML_DOC="""
+YAML_DOC = """
 name: ZenPacks.zenoss.ZenPackLib
 device_classes:
   /Device:
@@ -60,22 +69,23 @@ class TestZen24083(BaseTestCase):
     """
 
     def test_datasource_inheritance(self):
-        z = ZPLTestHarness(YAML_DOC)
-        z.connect()
-        self.assertTrue(z.check_templates_vs_yaml(), "Template objects do not match YAML")
-        self.assertTrue(z.check_templates_vs_specs(), "Template objects do not match Spec")
-        # check properties on dummy template
-        dcs = z.cfg.device_classes.get('/Device')
-        tcs = dcs.templates.get('TESTAGGFAIL')
-        t = tcs.create(z.dmd, False)
-        for ds in t.datasources():
-            # standard paramenter
-            self.assertEquals(ds.component, '${here/id}', 'datasource property (component) was not inherited from DEFAULTS')
-            # extraparams parameter
-            self.assertEquals(ds.targetDataSource, 'ethernetcmascd_64', 'datasource property (targetDataSource) was not inherited from DEFAULTS')
-            # test local override of DEFAULTS 
-            if ds.id == 'agg_in_octets':
-                self.assertEquals(ds.targetDataPoint, 'aggifHCOutOctets', 'datasource property (targetDataPoint) DEFAULTS override was not set')
+        if aggregator_installed():
+            z = ZPLTestHarness(YAML_DOC)
+            z.connect()
+            self.assertTrue(z.check_templates_vs_yaml(), "Template objects do not match YAML")
+            self.assertTrue(z.check_templates_vs_specs(), "Template objects do not match Spec")
+            # check properties on dummy template
+            dcs = z.cfg.device_classes.get('/Device')
+            tcs = dcs.templates.get('TESTAGGFAIL')
+            t = tcs.create(z.dmd, False)
+            for ds in t.datasources():
+                # standard paramenter
+                self.assertEquals(ds.component, '${here/id}', 'datasource property (component) was not inherited from DEFAULTS')
+                # extraparams parameter
+                self.assertEquals(ds.targetDataSource, 'ethernetcmascd_64', 'datasource property (targetDataSource) was not inherited from DEFAULTS')
+                # test local override of DEFAULTS
+                if ds.id == 'agg_in_octets':
+                    self.assertEquals(ds.targetDataPoint, 'aggifHCOutOctets', 'datasource property (targetDataPoint) DEFAULTS override was not set')
 
 
 

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_zen_25315.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_zen_25315.py
@@ -45,6 +45,15 @@ device_classes:
             parser: Auto
 """
 
+def win_shell_installed():
+    """Return True if ShellDataSource is installed"""
+    try:
+        from ZenPacks.zenoss.Microsoft.Windows.datasources.ShellDataSource import ShellDataSource
+    except ImportError:
+        pass
+    else:
+        return True
+    return False
 
 class TestZen25315(BaseTestCase):
     """
@@ -52,18 +61,19 @@ class TestZen25315(BaseTestCase):
     """
 
     def test_datasource_boolean(self):
-        z = ZPLTestHarness(YAML_DOC)
-        z.connect()
-        # check properties on dummy template
-        dcs = z.cfg.device_classes.get('/Server/Microsoft')
-        tcs = dcs.templates.get('TestTemplate')
-        t = tcs.create(z.dmd, False)
-        ds = t.datasources()[0]
+        if win_shell_installed():
+            z = ZPLTestHarness(YAML_DOC)
+            z.connect()
+            # check properties on dummy template
+            dcs = z.cfg.device_classes.get('/Server/Microsoft')
+            tcs = dcs.templates.get('TestTemplate')
+            t = tcs.create(z.dmd, False)
+            ds = t.datasources()[0]
 
-        self.assertTrue(isinstance(ds.usePowershell, bool),
-                'Datasource property (usePowershell) should be bool, got {}'.format(type(ds.usePowershell)))
-        self.assertEquals(ds.usePowershell, False,
-                'Datasource property (usePowershell) should be False, got {}'.format(ds.usePowershell))
+            self.assertTrue(isinstance(ds.usePowershell, bool),
+                    'Datasource property (usePowershell) should be bool, got {}'.format(type(ds.usePowershell)))
+            self.assertEquals(ds.usePowershell, False,
+                    'Datasource property (usePowershell) should be False, got {}'.format(ds.usePowershell))
 
 
 


### PR DESCRIPTION
- Fixes ZEN-25690
- Some unit tests depend on ZenPack-derived classes, so we cannot run
them if the dependencies are unsatisfied