### PR TITLE
Fix removal of Process and Event classes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@ Features
 * Added ZPLCommand to handle running zenpacklib with arguments
 * Separated zenpacklib.py classes into module files
 * Ability to use ZenPack-provided zenpacklib module
+* Added support for Process Class definitions
+
 
 Fixes
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -20,10 +20,22 @@ from Products.ZenModel.ZenPack import ZenPack as ZenPackBase
 from ..helpers.Dumper import Dumper
 from ..helpers.ZenPackLibLog import ZenPackLibLog, new_log
 from ..params.RRDTemplateSpecParams import RRDTemplateSpecParams
+from Products.ZenEvents import ZenEventClasses
 
 LOG = new_log('zpl.ZenPack')
 LOG.setLevel('INFO')
 ZenPackLibLog.enable_log_stderr(LOG)
+
+# We need to make sure we aren't removing an important/default event,
+# windows/ip service, or process class on ZenPack removal
+RESERVED_CLASSES = set(['/Status', '/App', '/Cmd', '/Perf',
+                        '/Heartbeat', '/Unknown', '/Change', 'Processes',
+                        'Services', 'WinService', 'IpService'])
+
+for x in dir(ZenEventClasses):
+    y = getattr(ZenEventClasses, x)
+    if isinstance(y, str):
+        RESERVED_CLASSES.add(y)
 
 
 class ZenPack(ZenPackBase):
@@ -50,7 +62,7 @@ class ZenPack(ZenPackBase):
                     d.buildRelations()
                 except ConflictError as e:
                     self.LOG.warn('Reattempting buildRelations() on {} ({})'.format(d.id, e))
-                    sync()
+                    self.dmd._p_jar.sync()
                     build_relations(d, retries, count + 1)
                 except Exception as e:
                     self.LOG.error('buildRelations() failed for {} ({})'.format(d.id, e))
@@ -203,29 +215,52 @@ class ZenPack(ZenPackBase):
                     self.remove_device_class(app, dcspec)
 
             # Remove EventClasses with remove flag set
-            for ecname, ecspec in self.event_classes.iteritems():
-                organizerPath = ecspec.path
-                if ecspec.remove:
-                    try:
-                        app.dmd.Events.getOrganizer(organizerPath)
-                    except KeyError:
-                        self.LOG.warning('Unable to remove EventClass %s (not found)' % ecspec.path)
-                        continue
-
-                    self.LOG.info('Removing EventClass %s' % ecspec.path)
-                    app.dmd.Events.manage_deleteOrganizer(organizerPath)
-                else:
-                    try:
-                        organizer = app.dmd.Events.getOrganizer(organizerPath)
-                    except KeyError:
-                        continue
-
-                    for mapping_id, mapping_spec in ecspec.mappings.items():
-                        if mapping_spec.remove:
-                            self.LOG.info('Removing EventClassInst %s @ %s' % (mapping_id, ecspec.path))
-                            organizer.removeInstances(organizer.prepId(mapping_id))
+            self.remove_organizer_or_subs(app.dmd.Events,
+                                          self.event_classes,
+                                          'mappings',
+                                          'removeInstances')
+            # Remove Process Classes/Organizers with remove flag set
+            self.remove_organizer_or_subs(app.dmd.Processes,
+                                          self.process_class_organizers,
+                                          'process_classes',
+                                          'removeOSProcessClasses')
 
         super(ZenPack, self).remove(app, leaveObjects=leaveObjects)
+
+    def remove_organizer_or_subs(self, dmd_root, classes, sub_class, remove_name):
+        '''Remove the organizer or subclasses within an organizer
+        Used for event classes, process classes, windows services
+        The specs should use path to describe the organizer name/path
+        For subclasses, use klass_string for the class type name
+        Also be sure to set zpl_managed in the specs
+        '''
+        for cname, cspec in classes.iteritems():
+            organizerPath = cspec.path
+            try:
+                organizer = dmd_root.getOrganizer(organizerPath)
+            except KeyError:
+                self.LOG.warning('Unable to find {} {}'.format(dmd_root.__class__.__name__, cspec.path))
+                continue
+            if cspec.remove and hasattr(organizer, 'zpl_managed') and organizer.zpl_managed:
+                # make sure the organizer is zpl_managed before we try and delete it
+                # also double-check that we do not remove anything important like /Status or Processes
+                if organizerPath in RESERVED_CLASSES:
+                    continue
+                self.LOG.info('Removing {} {}'.format(organizer.__class__.__name__, cspec.path))
+                dmd_root.manage_deleteOrganizer(organizerPath)
+            else:
+                sub_classes = getattr(cspec, sub_class, {})
+                remove_func = getattr(organizer, remove_name, None)
+                if not remove_func:
+                    continue
+                for subclass_id, subclass_spec in sub_classes.items():
+                    if subclass_spec.remove:
+                        preppedId = organizer.prepId(subclass_id)
+                        # make sure object is zpl managed
+                        obj = organizer.findObject(preppedId)
+                        if getattr(obj, 'zpl_managed', False):
+                            self.LOG.info('Removing {} {} @ {}'.format(subclass_spec.klass_string, subclass_id, cspec.path))
+                            remove_func(preppedId)
 
     def template_changed(self, app, existing, new_spec):
         """

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassOrganizerSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassOrganizerSpecParams.py
@@ -13,9 +13,10 @@ from ..spec.ProcessClassOrganizerSpec import ProcessClassOrganizerSpec
 
 
 class ProcessClassOrganizerSpecParams(SpecParams, ProcessClassOrganizerSpec):
-    def __init__(self, zenpack_spec, name, description='', process_classes=None, **kwargs):
+    def __init__(self, zenpack_spec, path, description='', process_classes=None, remove=False, **kwargs):
         SpecParams.__init__(self, **kwargs)
-        self.name = name
+        self.path = path
         self.description = description
+        self.remove = remove
         self.process_classes = self.specs_from_param(
             ProcessClassSpecParams, 'process_classes', process_classes)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassSpecParams.py
@@ -15,6 +15,7 @@ class ProcessClassSpecParams(SpecParams, ProcessClassSpec):
                  zenpack_spec,
                  name,
                  description='',
+                 remove=False,
                  include_processes='',
                  exclude_processes='',
                  replace_text='',
@@ -27,6 +28,8 @@ class ProcessClassSpecParams(SpecParams, ProcessClassSpec):
                  **kwargs):
         SpecParams.__init__(self, **kwargs)
         self.name = name
+        self.description = description
+        self.remove = remove
         self.include_processes = include_processes
         self.exclude_processes = exclude_processes
         self.replace_text = replace_text

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassMappingSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassMappingSpec.py
@@ -48,6 +48,7 @@ class EventClassMappingSpec(Spec):
           :type remove: bool
         """
         super(EventClassMappingSpec, self).__init__(_source_location=_source_location)
+        self.klass_string = 'EventClassInst'
         self.eventclass_spec = eventclass_spec
         self.name = name
         self.eventClassKey = eventClassKey
@@ -71,3 +72,5 @@ class EventClassMappingSpec(Spec):
         for x in _properties:
             if getattr(mapping, x) != getattr(self, x):
                 setattr(mapping, x, getattr(self, x, None))
+
+        self.zpl_managed = True

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
@@ -49,12 +49,15 @@ class EventClassSpec(Spec):
             EventClassMappingSpec, 'mappings', mappings, zplog=self.LOG)
 
     def instantiate(self, dmd):
+        bCreated = False
         if self.create:
             try:
-                dmd.Events.getOrganizer(self.path)
+                ecObject = dmd.Events.getOrganizer(self.path)
+                bCreated = getattr(ecObject, 'zpl_managed', False)
             except KeyError:
                 dmd.Events.createOrganizer(self.path)
-        ecObject = dmd.Events.getOrganizer(self.path)
+                ecObject = dmd.Events.getOrganizer(self.path)
+                bCreated = True
         if self.description != '':
             if not ecObject.description == self.description:
                 ecObject.description = self.description
@@ -63,6 +66,6 @@ class EventClassSpec(Spec):
                 ecObject.transform = self.transform
         # Flag this as a ZPL managed object, that is, one that should not be
         # exported to objects.xml  (contained objects will also be excluded)
-        ecObject.zpl_managed = True
+        ecObject.zpl_managed = bCreated
         for mapping_id, mapping_spec in self.mappings.items():
             mapping_spec.create(ecObject)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
@@ -17,8 +17,9 @@ class ProcessClassOrganizerSpec(Spec):
     def __init__(
             self,
             zenpack_spec,
-            name,
+            path,
             description='',
+            remove=False,
             process_classes=None,
             _source_location=None,
             zplog=None):
@@ -27,24 +28,30 @@ class ProcessClassOrganizerSpec(Spec):
           :type description: str
           :param process_classes: Process Class specs
           :type process_classes: SpecsParameter(ProcessClassSpec)
+          :param remove: Remove Organizer on ZenPack removal
+          :type remove: boolean
         """
-        self.name = name
+        self.path = path
         self.description = description
+        self.remove = remove
         self.process_classes = self.specs_from_param(
             ProcessClassSpec, 'process_classes', process_classes, zplog=self.LOG)
 
     def create(self, dmd):
         # get/create process class organizer
+        bCreated = False
         try:
-            porg = dmd.Processes.getOrganizer(self.name)
+            porg = dmd.Processes.getOrganizer(self.path)
+            bCreated = getattr(porg, 'zpl_managed', False)
         except KeyError:
-            manage_addOSProcessOrganizer(dmd.Processes, self.name)
-            porg = dmd.Processes.getOrganizer(self.name)
+            manage_addOSProcessOrganizer(dmd.Processes, self.path)
+            porg = dmd.Processes.getOrganizer(self.path)
+            bCreated = True
 
         if porg.description != self.description:
             porg.description = self.description
         # Flag this as a ZPL managed object, that is, one that should not be
         # exported to objects.xml  (contained objects will also be excluded)
-        porg.zpl_managed = True
+        porg.zpl_managed = bCreated
         for process_class_id, process_class_spec in self.process_classes.items():
             process_class_spec.create(dmd, porg)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassSpec.py
@@ -20,6 +20,7 @@ class ProcessClassSpec(Spec):
             zenpack_spec,
             name,
             description='',
+            remove=False,
             includeRegex='',
             excludeRegex='',
             replaceRegex='',
@@ -52,11 +53,15 @@ class ProcessClassSpec(Spec):
           :type modeler_lock: bool
           :param send_event_when_blocked: Send and event when action is blocked?
           :type send_event_when_blocked: bool
+          :param remove: Remove Organizer on ZenPack removal
+          :type remove: boolean
         """
         super(ProcessClassSpec, self).__init__(_source_location=_source_location)
+        self.klass_string = 'OSProcessClass'
         self.zenpack_spec = zenpack_spec
         self.name = name
         self.description = description
+        self.remove = remove
         if zplog:
             self.LOG = zplog
         try:


### PR DESCRIPTION
Fixes ZEN-25684

This updates the removal of Process and Event Classes.
We need to double check that we're not removing default classes
like '/Status' or 'Processes' or 'WinService'.  Also fixed how
we determine if a class organizer is 'zpl_managed'