### PR TITLE
Add proxies for all platform component classes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Features
 * Improve performance of entity properties in component grids.
 * Simplify what device status means to critical event(s) in /Status.
 * Improve grid performance with streamlined info adapters
+* Add base class proxies for all platform component classes.
 
 Fixes
 
@@ -29,11 +30,13 @@ Fixes
 * Ensure that subcomponent nav JS uses relationship label if given (ZEN-24305)
 * Fix for setting of zProperty values before zProperty exists
 * Fix "unexpected keyword default" message
+* Fix support for extending platform component classes. (ZEN-25559)
 
 Documentation
 
 * Fix YAML reference for dynamicview_group class field.
 * Fix documentation of default value for dynamicview_views.
+* Document new component class proxies such as IpInterface and FileSystem.
 
 
 Version 1.0

--- a/docs/yaml-classes-and-relationships.rst
+++ b/docs/yaml-classes-and-relationships.rst
@@ -55,7 +55,30 @@ If you need more than the standard classes provide, you will need to extend one
 of the following two base classes provided by zenpacklib.
 
 * zenpacklib.Device
+
 * zenpacklib.Component
+
+  * zenpacklib.HWComponent
+
+    * zenpacklib.CPU
+    * zenpacklib.ExpansionCard
+    * zenpacklib.Fan
+    * zenpacklib.HardDisk
+    * zenpacklib.PowerSupply
+    * zenpacklib.TemperatureSensor
+
+  * zenpacklib.OSComponent
+
+    * zenpacklib.FileSystem
+    * zenpacklib.IpInterface
+    * zenpacklib.IpRouteEntry
+    * zenpacklib.OSProcess
+    * zenpacklib.Software
+
+    * zenpacklib.Service
+
+      * zenpacklib.IpService
+      * zenpacklib.WinService
 
 You use *zenpacklib.Device* to create new device types of which instances will
 appear on the *Infrastructure* screen. You use *zenpacklib.Component* to create
@@ -66,6 +89,10 @@ example, a XenServer ZenPack would add a new device type called *Endpoint* which
 represents the XenAPI management interface. That *Endpoint* device type would
 have many components of types such as *Pool*, *StorageRepository* and
 *VirtualMachine*.
+
+The other supported classes are proxies for their platform equivalents, and are
+to be used when you want to extend one of the platform component types rather
+than creating a totally new component type.
 
 
 .. _zenpacklib-relationships:
@@ -197,7 +224,7 @@ name
   :Default Value: *(implied from key in classes map)*
 
 base
-  :Description: List of base classes to extend.
+  :Description: List of base classes to extend. See :ref:`Classes <zenpacklib-classes>`
   :Required: No
   :Type: list<classname>
   :Default Value: [zenpacklib.Component]

--- a/zenpacklib.py
+++ b/zenpacklib.py
@@ -70,10 +70,6 @@ from Products.AdvancedQuery import Eq, Or
 from Products.AdvancedQuery.AdvancedQuery import _BaseQuery as BaseQuery
 from Products.Five import zcml
 
-from Products.ZenModel.Device import Device as BaseDevice
-from Products.ZenModel.DeviceComponent import DeviceComponent as BaseDeviceComponent
-from Products.ZenModel.HWComponent import HWComponent as BaseHWComponent
-from Products.ZenModel.ManagedEntity import ManagedEntity as BaseManagedEntity
 from Products.ZenModel.ZenossSecurity import ZEN_CHANGE_DEVICE
 from Products.ZenModel.ZenPack import ZenPack as ZenPackBase
 from Products.ZenModel.CommentGraphPoint import CommentGraphPoint
@@ -92,6 +88,26 @@ from Products.ZenUI3.utils.javascript import JavaScriptSnippet
 from Products.ZenUtils.guid.interfaces import IGlobalIdentifier
 from Products.ZenUtils.Search import makeFieldIndex, makeKeywordIndex
 from Products.ZenUtils.Utils import monkeypatch, importClass
+
+# Extendable Model Classes
+from Products.ZenModel.CPU import CPU as BaseCPU
+from Products.ZenModel.Device import Device as BaseDevice
+from Products.ZenModel.DeviceComponent import DeviceComponent as BaseDeviceComponent
+from Products.ZenModel.ExpansionCard import ExpansionCard as BaseExpansionCard
+from Products.ZenModel.Fan import Fan as BaseFan
+from Products.ZenModel.FileSystem import FileSystem as BaseFileSystem
+from Products.ZenModel.HardDisk import HardDisk as BaseHardDisk
+from Products.ZenModel.HWComponent import HWComponent as BaseHWComponent
+from Products.ZenModel.IpInterface import IpInterface as BaseIpInterface
+from Products.ZenModel.IpRouteEntry import IpRouteEntry as BaseIpRouteEntry
+from Products.ZenModel.IpService import IpService as BaseIpService
+from Products.ZenModel.ManagedEntity import ManagedEntity as BaseManagedEntity
+from Products.ZenModel.OSComponent import OSComponent as BaseOSComponent
+from Products.ZenModel.OSProcess import OSProcess as BaseOSProcess
+from Products.ZenModel.PowerSupply import PowerSupply as BasePowerSupply
+from Products.ZenModel.Service import Service as BaseService
+from Products.ZenModel.TemperatureSensor import TemperatureSensor as BaseTemperatureSensor
+from Products.ZenModel.WinService import WinService as BaseWinService
 
 from Products import Zuul
 from Products.Zuul import marshal
@@ -1318,20 +1334,32 @@ def DeviceTypeFactory(name, bases):
     return device_type
 
 
-Device = DeviceTypeFactory(
-    'Device', (BaseDevice,))
-
-
 def ComponentTypeFactory(name, bases):
     """Return a "ZenPackified" component class given bases tuple."""
     return ModelTypeFactory(name, (ComponentBase,) + bases)
 
 
-Component = ComponentTypeFactory(
-    'Component', (BaseDeviceComponent, BaseManagedEntity))
+# Model Extension Classes
+Component = ComponentTypeFactory('Component', (BaseDeviceComponent, BaseManagedEntity))
+CPU = ComponentTypeFactory('CPU', (BaseCPU,))
+Device = DeviceTypeFactory('Device', (BaseDevice,))
+ExpansionCard = ComponentTypeFactory('ExpansionCard', (BaseExpansionCard,))
+Fan = ComponentTypeFactory('Fan', (BaseFan,))
+FileSystem = ComponentTypeFactory('FileSystem', (BaseFileSystem,))
+HardDisk = ComponentTypeFactory('HardDisk', (BaseHardDisk,))
+HWComponent = ComponentTypeFactory('HWComponent', (BaseHWComponent,))
+IpInterface = ComponentTypeFactory('IpInterface', (BaseIpInterface,))
+IpRouteEntry = ComponentTypeFactory('IpRouteEntry', (BaseIpRouteEntry,))
+IpService = ComponentTypeFactory('IpService', (BaseIpService,))
+OSComponent = ComponentTypeFactory('OSComponent', (BaseOSComponent,))
+OSProcess = ComponentTypeFactory('OSProcess', (BaseOSProcess,))
+PowerSupply = ComponentTypeFactory('PowerSupply', (BasePowerSupply,))
+Service = ComponentTypeFactory('Service', (BaseService,))
+TemperatureSensor = ComponentTypeFactory('TemperatureSensor', (BaseTemperatureSensor,))
+WinService = ComponentTypeFactory('WinService', (BaseWinService,))
 
-HardwareComponent = ComponentTypeFactory(
-    'HardwareComponent', (BaseHWComponent,))
+# Backwards-compatibility aliases.
+HardwareComponent = HWComponent
 
 
 class IHardwareComponentInfo(IBaseComponentInfo):


### PR DESCRIPTION
ZenPacks have been created that wanted to extend platform component
classes such as IpInterface and FileSystem. The mechanism they used to
do this was to set the base classes to zenpacklib.Component first, and
something like Products.ZenModel.IpInterface.IpInterface second. This
resulted in buggy behavior because IpInterface behavior such as its
index_object() method would never be called.

Introducing zenpacklib proxies for all platform component classes solves
this problem because it puts a zenpacklib class as the single parent
class. This allows zenpacklib to properly fan out calls to things like
index_object() to all necessary parent classes.

Refs ZEN-25559.