### PR TITLE
Use Spec/SpecParams init_params as a class property (10-25% reduced load time)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -36,7 +36,7 @@ class Dumper(yaml.Dumper):
         be used for this specific zenpacklib.
     """
 
-    LOG=DEFAULTLOG
+    LOG = DEFAULTLOG
 
     def dict_representer(self, data):
         return yaml.MappingNode(u'tag:yaml.org,2002:map', data.items())
@@ -67,7 +67,6 @@ class Dumper(yaml.Dumper):
         elif v_type == 'Severity':
             return self.represent_str(self.severity_to_str(value))
         else:
-            
             m = re.match('^SpecsParameter\((.*)\)$', v_type)
             if m:
                 spectype = m.group(1)
@@ -119,7 +118,7 @@ class Dumper(yaml.Dumper):
 
         mapping = OrderedDict()
 
-        param_defs = cls.init_params()
+        param_defs = cls.init_params
 
         for p_name, p_data in param_defs.iteritems():
             # determine what type of object this is

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
@@ -52,7 +52,7 @@ class Loader(yaml.Loader):
                 node.start_mark))
             return
 
-        param_defs = spec_class.init_params()
+        param_defs = spec_class.init_params
         specs = OrderedDict()
         for spec_key_node, spec_value_node in node.value:
             try:
@@ -78,7 +78,7 @@ class Loader(yaml.Loader):
             return dict(shorthand=self.construct_scalar(node))
 
         # dictionary of class initialization parameters
-        param_defs = cls.init_params()
+        param_defs = cls.init_params
         # create new dictionary containing instance parameters
         params = {}
         # raise an error if this won't parse correctly

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatapointSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatapointSpecParams.py
@@ -42,7 +42,7 @@ class RRDDatapointSpecParams(SpecParams, RRDDatapointSpec):
 
         self.extra_params = OrderedDict()
         for propname in [x['id'] for x in datapoint._properties]:
-            if propname not in self.init_params():
+            if propname not in self.init_params:
                 if getattr(datapoint, propname, None) != getattr(sample_dp, propname, None):
                     self.extra_params[propname] = getattr(datapoint, propname, None)
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatasourceSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatasourceSpecParams.py
@@ -41,7 +41,7 @@ class RRDDatasourceSpecParams(SpecParams, RRDDatasourceSpec):
 
         self.extra_params = OrderedDict()
         for propname in [x['id'] for x in datasource._properties]:
-            if propname not in self.init_params():
+            if propname not in self.init_params:
                 if getattr(datasource, propname, None) != getattr(sample_ds, propname, None):
                     self.extra_params[propname] = getattr(datasource, propname, None)
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RRDThresholdSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RRDThresholdSpecParams.py
@@ -32,7 +32,7 @@ class RRDThresholdSpecParams(SpecParams, RRDThresholdSpec):
 
         self.extra_params = OrderedDict()
         for propname in [x['id'] for x in threshold._properties]:
-            if propname not in self.init_params():
+            if propname not in self.init_params:
                 if getattr(threshold, propname, None) != getattr(sample_th, propname, None):
                     self.extra_params[propname] = getattr(threshold, propname, None)
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -20,6 +20,7 @@ from Products.Zuul.interfaces import IInfo
 
 from ..functions import fix_kwargs, create_module
 from ..helpers.ZenPackLibLog import DEFAULTLOG
+from ..base.ClassProperty import ClassProperty
 
 
 def MethodInfoProperty(method_name, entity=False, enum=None):
@@ -43,7 +44,7 @@ def MethodInfoProperty(method_name, entity=False, enum=None):
         else:
             if enum and isinstance(enum, dict):
                 try:
-                    return enum.get(int(result),'Unknown')
+                    return enum.get(int(result), 'Unknown')
                 except Exception:
                     return result
             else:
@@ -139,7 +140,7 @@ class Spec(object):
 
     source_location = None
     speclog = None
-
+    _init_params = None
     LOG = DEFAULTLOG
 
     def __init__(self, _source_location=None, zplog=None):
@@ -202,7 +203,7 @@ class Spec(object):
             for k, v in dictionary.iteritems():
                 dictionary[k] = dict(defaults, **v)
                 if 'extra_params' in dictionary[k].keys():
-                    extra_params = defaults.get('extra_params',{})
+                    extra_params = defaults.get('extra_params', {})
                     dictionary_params = dictionary[k]['extra_params']
                     for i, j in extra_params.items():
                         if i not in dictionary_params.keys():
@@ -233,8 +234,15 @@ class Spec(object):
 
         return specs
 
+    @ClassProperty
     @classmethod
     def init_params(cls):
+        if not cls._init_params:
+            cls._init_params = cls.get_init_params()
+        return cls._init_params
+
+    @classmethod
+    def get_init_params(cls):
         """Return a dictionary describing the parameters accepted by __init__"""
 
         argspec = inspect.getargspec(cls.__init__)
@@ -283,7 +291,7 @@ class Spec(object):
         if type(self) != type(other):
             return False
 
-        params = self.init_params()
+        params = self.init_params
         for p in params:
             if p in ignore_params:
                 continue
@@ -324,10 +332,10 @@ class Spec(object):
         """Create and return described class."""
         if isinstance(module, basestring):
             module = create_module(module)
-    
+
         schema_class = self.create_schema_class(
             schema_module, classname, bases, attributes)
-    
+
         return self.create_stub_class(module, schema_class, classname)
 
     def create_schema_class(self, schema_module, classname, bases, attributes):


### PR DESCRIPTION
- init_params is now a cached class property
- eliminates multiple runs of "init_params() method"
- corrected SpecParams overwrite of Spec init_params "type"