### PR TITLE
Input validation for severity, color attributes

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
@@ -1,0 +1,99 @@
+from ..helpers.ZenPackLibLog import DEFAULTLOG as LOG
+
+import string
+
+class Color(str):
+    """Hexadecimal string representation for color"""
+    def __new__(cls, value):
+        return str.__new__(cls, cls.validate(value))
+
+    @classmethod
+    def validate(cls, value):
+        if not value:
+            return value
+        value = str(value)
+        # truncate or pad with 0s
+        def check_length(value):
+            if len(value) > 6:
+                LOG.warning('Max length exceeded, truncating: {}'.format(value))
+                value = value[:6]
+            elif len(value) < 6:
+                LOG.warning('Min length not met, padding: {}'.format(value))
+                value += '0'
+                value = check_length(value)
+            return value
+
+        def is_hex(value):
+            return all(v in string.hexdigits for v in value)
+
+        def fix_hex(value):
+            '''fix invalid hex values'''
+            color = ''
+            for v in value:
+                if not v in string.hexdigits:
+                    v = 'F'
+                color += v
+            return color
+
+        value = check_length(value)
+
+        if not is_hex(value):
+            LOG.warning('Invalid Hex value given: {}, returning {}'.format(value, fix_hex(value)))
+            value = fix_hex(value)
+        return value.upper()
+
+
+class Severity(int):
+    """Represent severity as number or text while preserving user designation"""
+
+    orig = None
+    num = None
+    text = None
+
+    _valid_text = ['crit', 'critical', 'err', 'error',
+                   'warn', 'warning', 'info', 'information', 'informational',
+                   'debug', 'debugging', 'clear']
+
+    _valid_num = [0, 1, 2, 3, 4, 5]
+
+    to_text = {5: 'critical', 4: 'error', 3: 'warn',
+               2: 'info', 1: 'debug', 0: 'clear'}
+
+    to_num = {'crit': 5, 'critical': 5, 'err': 4, 'error': 4,
+               'warn': 3, 'warning': 3,
+               'info': 2, 'information': 2, 'informational': 2,
+               'debug': 1, 'debugging': 1,
+               'clear': 0}
+
+    def __new__(cls, value):
+        if not value:
+            return value
+        return int.__new__(cls, cls.validate(value))
+
+    @classmethod
+    def validate(cls, value):
+        try:
+            value = int(value)
+            if value < 0:
+                LOG.warning("Invalid severity value ({}), increasing to 0".format(value))
+                value = 0
+            elif value > 5:
+                LOG.warning("Invalid severity value ({}), reducing to 5".format(value))
+                value = 5
+        except (TypeError, ValueError):
+            if isinstance(value, str):
+                if value.lower() in cls._valid_text:
+                    value = cls.to_num.get(value.lower())
+                else:
+                    sev_num_txt = [str(x) for x in cls._valid_num]
+                    LOG.warning("Invalid severity value ({}), "\
+                        "must be one of: ({}) or ({}).".format(value,
+                                                ', '.join(cls._valid_text),
+                                                ', '.join(sev_num_txt)))
+                    value = 3
+        return value
+
+    def __init__(self, value):
+        self.orig = value
+        self.text = self.to_text.get(self)
+

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -62,10 +62,6 @@ class Dumper(yaml.Dumper):
                 return self.represent_list(classes)
             else:
                 return self.represent_list(value)
-        elif v_type == 'RelationshipSchemaSpec':
-            return self.represent_str(self.relschemaspec_to_str(value))
-        elif v_type == 'Severity':
-            return self.represent_str(self.severity_to_str(value))
         else:
             m = re.match('^SpecsParameter\((.*)\)$', v_type)
             if m:
@@ -201,6 +197,17 @@ class Dumper(yaml.Dumper):
             value.append((node_key, node_value))
         return yaml.MappingNode(u'tag:yaml.org,2002:map', value)
 
+    def represent_severity(self, data):
+        """represent Severity"""
+        orig = getattr(data, 'orig')
+        if orig:
+            if isinstance(orig, str):
+                return self.represent_str(orig)
+            elif isinstance(orig, int):
+                return self.represent_int(orig)
+        if orig is None:
+            raise ValueError("'{}' is not a valid value for severity.".format(orig))
+
     def relschemaspec_to_str(self, spec):
         # Omit relation names that are their defaults.
         left_optrelname = "" if spec.left_relname == spec.default_left_relname else "({})".format(spec.left_relname)
@@ -294,3 +301,7 @@ Dumper.add_representer(EventClassSpecParams, Dumper.represent_spec)
 Dumper.add_representer(EventClassMappingSpec, Dumper.represent_spec)
 Dumper.add_representer(ProcessClassOrganizerSpecParams, Dumper.represent_spec)
 Dumper.add_representer(ProcessClassSpecParams, Dumper.represent_spec)
+# representers for custom types
+from ..base.types import Color, Severity
+Dumper.add_representer(Color, SafeRepresenter.represent_str)
+Dumper.add_representer(Severity, Dumper.represent_severity)

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
@@ -15,6 +15,7 @@ import keyword
 from collections import OrderedDict
 from ..functions import ZENOSS_KEYWORDS, JS_WORDS, relname_from_classname, find_keyword_cls
 from .ZenPackLibLog import ZPLOG, DEFAULTLOG
+from ..base.types import Color, Severity
 
 
 class Loader(yaml.Loader):
@@ -32,6 +33,15 @@ class Loader(yaml.Loader):
     def dict_constructor(self, node):
         """constructor for OrderedDict"""
         return OrderedDict(self.construct_pairs(node))
+
+    def construct_severity(self, node):
+        value = node.value
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            value = str(value)
+        sev = Severity(value)
+        return sev.orig
 
     def construct_specsparameters(self, node, spectype):
         """constructor for SpecsParameters"""
@@ -210,8 +220,7 @@ class Loader(yaml.Loader):
                     yaml_value = self.str_to_relschemaspec(schemastr)
 
                 elif expected_type == 'Severity':
-                    severitystr = self.construct_python_str(value_node)
-                    yaml_value = self.str_to_severity(severitystr)
+                    yaml_value = self.construct_severity(value_node)
 
                 elif re.match('^SpecsParameter\((.*)\)$', expected_type):
                     m = re.match('^SpecsParameter\((.*)\)$', expected_type)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
@@ -9,6 +9,7 @@
 from Products.ZenModel.GraphPoint import GraphPoint
 from Products.ZenModel.DataPointGraphPoint import DataPointGraphPoint
 from Products.ZenModel.ComplexGraphPoint import ComplexGraphPoint
+from ..base.types import Color
 from .Spec import Spec
 
 
@@ -78,7 +79,7 @@ class GraphPointSpec(Spec):
         self.limit = limit
         self.rpn = rpn
         self.cFunc = cFunc
-        self.color = color
+        self.color = Color(color)
         self.includeThresholds = includeThresholds
 
         # Shorthand for datapoints that have the same name as their datasource.

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassSpec.py
@@ -9,6 +9,7 @@
 
 import re
 from .Spec import Spec
+from ..base.types import Severity
 
 """Process Class Specs"""
 
@@ -47,10 +48,10 @@ class ProcessClassSpec(Spec):
           :type monitor: bool
           :param alert_on_restart: Send Event on Restart?
           :type alert_on_restart: bool
-          :param fail_severity: Failure Event Severity
-          :type fail_severity: bool
-          :param modeler_lock: Lock Process Components?
-          :type modeler_lock: bool
+          :param fail_severity: Failure Event Severity (0-5)
+          :type fail_severity: Severity
+          :param modeler_lock: Lock Process Components, should be one of 0 (UNLOCKED), 1 (DELETE_LOCKED), 2 (UPDATE_LOCKED)
+          :type modeler_lock: int
           :param send_event_when_blocked: Send and event when action is blocked?
           :type send_event_when_blocked: bool
           :param remove: Remove Organizer on ZenPack removal
@@ -85,7 +86,7 @@ class ProcessClassSpec(Spec):
         self.replacement = replacement
         self.monitor = monitor
         self.alert_on_restart = alert_on_restart
-        self.fail_severity = fail_severity
+        self.fail_severity = Severity(fail_severity)
         self.modeler_lock = modeler_lock
         self.send_event_when_blocked = send_event_when_blocked
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatasourceSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatasourceSpec.py
@@ -8,6 +8,7 @@
 ##############################################################################
 from .Spec import Spec
 from .RRDDatapointSpec import RRDDatapointSpec
+from ..base.types import Severity
 
 class RRDDatasourceSpec(Spec):
     """RRDDatasourceSpec"""
@@ -63,7 +64,7 @@ class RRDDatasourceSpec(Spec):
         self.component = component
         self.eventClass = eventClass
         self.eventKey = eventKey
-        self.severity = severity
+        self.severity = Severity(severity)
         self.commandTemplate = commandTemplate
         if extra_params is None:
             self.extra_params = {}

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDThresholdSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDThresholdSpec.py
@@ -7,6 +7,8 @@
 #
 ##############################################################################
 from .Spec import Spec
+from ..base.types import Severity
+
 
 class RRDThresholdSpec(Spec):
     """RRDThresholdSpec"""
@@ -50,7 +52,7 @@ class RRDThresholdSpec(Spec):
         self.template_spec = template_spec
         self.dsnames = dsnames
         self.eventClass = eventClass
-        self.severity = severity
+        self.severity = Severity(severity)
         self.enabled = enabled
         self.type_ = type_
         if extra_params is None:

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_color_validation.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_color_validation.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+""" Color format validation YAML dump/load
+
+"""
+# zenpacklib Imports
+import yaml
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Loader import Loader
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Dumper import Dumper
+
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+YAML_DOC = """
+name: ZenPacks.zenoss.ZenPackLib
+device_classes:
+  /Server:
+    templates:
+      TEST:
+        datasources:
+          test:
+            datapoints:
+              a: GAUGE
+              b: GAUGE
+              c: GAUGE
+        graphs:
+          Graph:
+            graphpoints:
+              A:
+                dpName: test_a
+                color: 007700
+              B:
+                dpName: test_b
+                color: FF3300
+              C:
+                dpName: test_c
+                color: 0000BB
+              D:
+                dpName: test_c
+                color: 000
+              E:
+                dpName: test_c
+                color: JJJ0020
+"""
+
+EXPECTED = """name: ZenPacks.zenoss.ZenPackLib
+device_classes:
+  /Server:
+    templates:
+      TEST:
+        datasources:
+          test:
+            datapoints:
+              a: GAUGE
+              b: GAUGE
+              c: GAUGE
+        graphs:
+          Graph:
+            graphpoints:
+              A:
+                dpName: test_a
+                color: '007700'
+              B:
+                dpName: test_b
+                color: FF3300
+              C:
+                dpName: test_c
+                color: 0000BB
+              D:
+                dpName: test_c
+                color: '000000'
+              E:
+                dpName: test_c
+                color: FFF002
+"""
+
+class TestValidInput(BaseTestCase):
+    """Test color input validation"""
+
+    def test_valid_color(self):
+        ''''''
+        loaded = yaml.load(YAML_DOC, Loader=Loader)
+        dumped = yaml.dump(loaded, Dumper=Dumper)
+
+
+        self.assertEquals(dumped, EXPECTED,
+                        'YAML Color validation test failed')
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestValidInput))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_severity_validation.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_severity_validation.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+""" Color format validation YAML dump/load
+
+"""
+# zenpacklib Imports
+import yaml
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Loader import Loader
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.Dumper import Dumper
+
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
+
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+YAML_DOC = """
+name: ZenPacks.zenoss.ZenPackLib
+device_classes:
+  /Device:
+    templates:
+      TEST:
+        datasources:
+          A:
+            type: SNMP
+            severity: 5
+            datapoints:
+              A: {}
+            oid: .1.3.6.1.4.1.232.6.2.6.8.1.4
+        thresholds:
+          A:
+            type: MinMaxThreshold
+            dsnames: [A_A]
+            severity: 3
+          B:
+            type: MinMaxThreshold
+            dsnames: [A_A]
+            severity: Warning
+          C:
+            type: MinMaxThreshold
+            dsnames: [A_A]
+            severity: warning
+          D:
+            type: MinMaxThreshold
+            dsnames: [A_A]
+            severity: NotSure
+          E:
+            type: MinMaxThreshold
+            dsnames: [A_A]
+"""
+
+
+EXPECTED = """name: ZenPacks.zenoss.ZenPackLib
+device_classes:
+  /Device:
+    templates:
+      TEST:
+        thresholds:
+          A:
+            dsnames: [A_A]
+            severity: 3
+          B:
+            dsnames: [A_A]
+            severity: Warning
+          C:
+            dsnames: [A_A]
+            severity: warning
+          D:
+            dsnames: [A_A]
+            severity: NotSure
+          E:
+            dsnames: [A_A]
+        datasources:
+          A:
+            type: SNMP
+            severity: 5
+            datapoints:
+              A: {}
+            oid: .1.3.6.1.4.1.232.6.2.6.8.1.4
+"""
+
+class TestValidSeverity(BaseTestCase):
+    """Test color input validation"""
+
+    def test_valid_color(self):
+        ''''''
+        loaded = yaml.load(YAML_DOC, Loader=Loader)
+        dumped = yaml.dump(loaded, Dumper=Dumper)
+
+        self.assertEquals(dumped, EXPECTED,
+                        'YAML severity validation test failed, got: \n{}'.format(dumped))
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestValidSeverity))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()


### PR DESCRIPTION
- Ensure that color is a 6-digit hexadecimal string
- Added Color class (string subclass) to perform validation
- Color class pads/truncates as needed, substituting 'F' for any non-hex
character
- Added Dumper representer for Color
- added test_color_validation unit test

Data input validation for severity attribute

- Ensures numerical value between 0 and 5 while accepting a range of
string values
- Preserves original user input in YAML
- added test_severity_validation