### PR TITLE
fix MethodInfo property return

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -50,6 +50,8 @@ def MethodInfoProperty(method_name, entity=False, enum=None):
             else:
                 return result
 
+    return property(getter)
+
 def EnumInfoProperty(data, enum):
     """Return a property filtered via an enum."""
     def getter(self, data, enum):


### PR DESCRIPTION
- method properties were returning None due to unintentional deletion of
line in MethodInfoProperty