### PR TITLE
Fix Unit Test Failure (test_template_modify) (Fixes ZEN-25916)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
@@ -79,7 +79,9 @@ class GraphPointSpec(Spec):
         self.limit = limit
         self.rpn = rpn
         self.cFunc = cFunc
-        self.color = Color(color)
+        self.color = color
+        if color:
+            self.color = Color(color)
         self.includeThresholds = includeThresholds
 
         # Shorthand for datapoints that have the same name as their datasource.

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_color_validation.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_color_validation.py
@@ -54,6 +54,8 @@ device_classes:
               E:
                 dpName: test_c
                 color: JJJ0020
+              F:
+                dpName: test_c
 """
 
 EXPECTED = """name: ZenPacks.zenoss.ZenPackLib
@@ -85,6 +87,8 @@ device_classes:
               E:
                 dpName: test_c
                 color: FFF002
+              F:
+                dpName: test_c
 """
 
 class TestValidInput(BaseTestCase):


### PR DESCRIPTION
- only set GraphPointSpec Color paramter if not None
- updated test_color_validation to handle None case