### PR TITLE
Revise class proxies Info and Interfaces classes (ZEN-25948)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/info.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/info.py
@@ -10,18 +10,17 @@ from zope.component import adapts
 from zope.interface import  implements
 from Products.Zuul.decorators import info
 from Products.Zuul.infos.component import ComponentInfo
-from .base.HardwareComponent import HardwareComponent
-from .interfaces import IHardwareComponentInfo
+from .base.Component import HWComponent, HardwareComponent
+from .interfaces import IHWComponentInfo, IHardwareComponentInfo
 
-class HardwareComponentInfo(ComponentInfo):
+class HWComponentInfo(ComponentInfo):
 
-    """Info adapter factory for ZenPackHardwareComponent.
-
+    """Info adapter factory for ZPL HWComponent.
     This exists because Zuul has no HWComponent info adapter.
     """
 
-    implements(IHardwareComponentInfo)
-    adapts(HardwareComponent)
+    implements(IHWComponentInfo)
+    adapts(HWComponent)
 
     @property
     @info
@@ -37,3 +36,4 @@ class HardwareComponentInfo(ComponentInfo):
         """Return Info for hardware product class."""
         return self._object.productClass()
 
+HardwareComponentInfo = HWComponentInfo

--- a/ZenPacks/zenoss/ZenPackLib/lib/interfaces.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/interfaces.py
@@ -10,9 +10,9 @@ from Products.Zuul.form import schema
 from Products.Zuul.interfaces.component import IComponentInfo
 
 
-class IHardwareComponentInfo(IComponentInfo):
+class IHWComponentInfo(IComponentInfo):
 
-    """Info interface for ZenPackHardwareComponent.
+    """Info interface for ZPL HWComponent.
 
     This exists because Zuul has no HWComponent info interface.
     """
@@ -20,3 +20,5 @@ class IHardwareComponentInfo(IComponentInfo):
     manufacturer = schema.Entity(title=u'Manufacturer')
     product = schema.Entity(title=u'Model')
 
+
+IHardwareComponentInfo = IHWComponentInfo

--- a/ZenPacks/zenoss/ZenPackLib/lib/zuul.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/zuul.py
@@ -1,0 +1,79 @@
+from .base.Device import Device
+from .base.Component import (
+    Component,
+    HWComponent,
+    HardwareComponent,
+    CPU,
+    ExpansionCard,
+    Fan,
+    HardDisk,
+    PowerSupply,
+    TemperatureSensor,
+    OSComponent,
+    FileSystem,
+    IpInterface,
+    IpRouteEntry,
+    OSProcess,
+    Service,
+    IpService,
+    WinService
+    )
+
+from Products.Zuul.infos.device import DeviceInfo
+from Products.Zuul.interfaces.device import IDeviceInfo
+
+from Products.Zuul.infos.component import ComponentInfo
+from Products.Zuul.infos.component.cpu import CPUInfo
+from Products.Zuul.infos.component.expansioncard import ExpansionCardInfo
+from Products.Zuul.infos.component.fan import FanInfo
+from Products.Zuul.infos.component.powersupply import PowerSupplyInfo
+from Products.Zuul.infos.component.temperaturesensor import TemperatureSensorInfo
+from Products.Zuul.infos.component.filesystem import FileSystemInfo
+from Products.Zuul.infos.component.ipinterface import IpInterfaceInfo
+from Products.Zuul.infos.component.iprouteentry import IpRouteEntryInfo
+from Products.Zuul.infos.component.osprocess import OSProcessInfo
+from Products.Zuul.infos.component.ipservice import IpServiceInfo
+from Products.Zuul.infos.component.winservice import WinServiceInfo
+from Products.Zuul.interfaces.component import (
+    IComponentInfo,
+    ICPUInfo,
+    IExpansionCardInfo,
+    IFanInfo,
+    IPowerSupplyInfo,
+    ITemperatureSensorInfo,
+    IFileSystemInfo,
+    IIpInterfaceInfo,
+    IIpRouteEntryInfo,
+    IOSProcessInfo,
+    IIpServiceInfo,
+    IWinServiceInfo
+    )
+
+from Products.Zuul.infos.service import ServiceInfo
+from Products.Zuul.interfaces.service import IServiceInfo
+
+from .info import HWComponentInfo
+from .interfaces import IHWComponentInfo
+
+
+schema_map = {
+     Device: {'interface': IDeviceInfo, 'info': DeviceInfo},
+     Component: {'interface': IComponentInfo, 'info': ComponentInfo},
+     HWComponent: {'interface': IHWComponentInfo, 'info': HWComponentInfo},
+     HardwareComponent: {'interface': IHWComponentInfo, 'info': HWComponentInfo},
+     CPU: {'interface': ICPUInfo, 'info': CPUInfo},
+     ExpansionCard: {'interface': IExpansionCardInfo, 'info': ExpansionCardInfo},
+     Fan: {'interface': IFanInfo, 'info': FanInfo},
+     HardDisk: {'interface': IHWComponentInfo, 'info': HWComponentInfo},
+     PowerSupply: {'interface': IPowerSupplyInfo, 'info': PowerSupplyInfo},
+     TemperatureSensor: {'interface': ITemperatureSensorInfo, 'info': TemperatureSensorInfo},
+     OSComponent: {'interface': IComponentInfo, 'info': ComponentInfo},
+     FileSystem: {'interface': IFileSystemInfo, 'info': FileSystemInfo},
+     IpInterface: {'interface': IIpInterfaceInfo, 'info': IpInterfaceInfo},
+     IpRouteEntry: {'interface': IIpRouteEntryInfo, 'info': IpRouteEntryInfo},
+     OSProcess: {'interface': IOSProcessInfo, 'info': OSProcessInfo},
+     Service: {'interface': IServiceInfo, 'info': ServiceInfo},
+     IpService: {'interface': IIpServiceInfo, 'info': IpServiceInfo},
+     WinService: {'interface': IWinServiceInfo, 'info': WinServiceInfo},
+     }
+


### PR DESCRIPTION
- added zuul.py with schema_map dictionary mapping each proxy class to
appropriate info and interface class
- updated ClassSpec create_info_schema_class and
create_iinfo_schema_class methods to use schema_map when determining
base classes
- fixed ImportError for HardwareComponent class (ZEN-25948)