### PR TITLE
DO NOT MERGE

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
@@ -2,6 +2,51 @@ from ..helpers.ZenPackLibLog import DEFAULTLOG as LOG
 
 import string
 
+
+from Products.ZenRelations.RelSchema import ToMany, ToManyCont, ToOne
+
+class Relationship(str):
+    cls = None
+    name = None
+    cardinality = None
+
+    _relTypeCardinality = {
+        'ToOne': '1',
+        'ToMany': 'M',
+        'ToManyCont': 'MC'
+    }
+
+    _relTypeClasses = {
+        "ToOne": ToOne,
+        "ToMany": ToMany,
+        "ToManyCont": ToManyCont
+    }
+
+    _relTypeNames = {
+        ToOne: "ToOne",
+        ToMany: "ToMany",
+        ToManyCont: "ToManyCont"
+    }
+
+    def __new__(cls, value):
+        return str.__new__(cls, cls.validate(value))
+
+    @classmethod
+    def validate(cls, value):
+        if not value:
+            raise ValueError('Relationship cannot be None')
+        if not isinstance(value, str):
+            raise ValueError('Invalid type ({}) given for Relationship'.format(type(value)))
+        if value not in ['ToOne', 'ToMany', 'ToManyCont']:
+            raise ValueError('Invalid value ({}) given for Relationship'.format(value))
+        return value
+
+    def __init__(self, value):
+        self.name = value
+        self.cls = self._relTypeClasses.get(value)
+        self.cardinality = self._relTypeCardinality.get(value)
+
+
 class Color(str):
     """Hexadecimal string representation for color"""
     def __new__(cls, value):

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
@@ -32,17 +32,10 @@ class ZenPackSpecParams(SpecParams, ZenPackSpec):
         self.zProperties = self.specs_from_param(
             ZPropertySpecParams, 'zProperties', zProperties, leave_defaults=True, zplog=self.LOG)
 
-        self.class_relationships = []
-        if class_relationships:
-            if not isinstance(class_relationships, list):
-                raise ValueError("class_relationships must be a list, not a %s" % type(class_relationships))
-
-            for rel in class_relationships:
-                rel['zplog'] = self.LOG
-                self.class_relationships.append(RelationshipSchemaSpec(self, **rel))
-
         self.classes = self.specs_from_param(
             ClassSpecParams, 'classes', classes, leave_defaults=True, zplog=self.LOG)
+
+        self.class_relationships = class_relationships
 
         self.device_classes = self.specs_from_param(
             DeviceClassSpecParams, 'device_classes', device_classes, leave_defaults=True, zplog=self.LOG)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
@@ -156,6 +156,16 @@ class ClassPropertySpec(Spec):
         else:
             self.order = 4 + (max(0, min(100, order)) / 100.0)
 
+    def update_inherited_params(self):
+        """Copy any inherited parameters if they are not default or already specified here"""
+        custom = self.get_custom_params()
+        prop_spec = self.class_spec.find_property_in_base_specs(self.name)
+        if not prop_spec:
+            return
+        for k, v in prop_spec.get_custom_params().items():
+            if k not in custom:
+                setattr(self, k, v)
+
     @property
     def ofs_dict(self):
         """Return OFS _properties dictionary."""

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -10,6 +10,8 @@ import os
 import math
 import re
 import time
+import copy
+
 from zope.interface import classImplements
 from Products.Zuul.decorators import memoize
 from Products.Zuul.utils import ZuulMessageFactory as _t
@@ -17,18 +19,24 @@ from Products.ZenRelations.RelSchema import ToMany, ToManyCont
 from Products.Zuul.form import schema
 from Products.Zuul.form.interfaces import IFormBuilder
 from Products.Zuul.infos import InfoBase, ProxyProperty
+from Products.Zuul.infos.component import ComponentInfo
+from Products.Zuul.infos.device import DeviceInfo
 from Products.Zuul.interfaces import IInfo
+from Products.Zuul.interfaces.component import IComponentInfo
+from Products.Zuul.interfaces.device import IDeviceInfo
 
 from ..wrapper.ComponentFormBuilder import ComponentFormBuilder
+from ..info import HardwareComponentInfo
+from ..interfaces import IHardwareComponentInfo
 from ..utils import impact_installed, dynamicview_installed, has_metricfacade, FACET_BLACKLIST
 
 from ..gsm import get_gsm
 from ..functions import pluralize, get_symbol_name, relname_from_classname, \
     get_zenpack_path, ordered_values
 
-from ..base.Component import Component, HWComponent, Service
+from ..base.HardwareComponent import HardwareComponent
+from ..base.Component import Component
 from ..base.Device import Device
-from ..zuul import schema_map
 
 DYNAMICVIEW_INSTALLED = dynamicview_installed()
 if DYNAMICVIEW_INSTALLED:
@@ -104,6 +112,8 @@ class ClassSpec(Spec):
     _info_class = None
     _formbuilder_class = None
     _icon_url = None
+    _plumbed = False
+    _property_defaults = {}
 
     def __init__(
             self,
@@ -204,6 +214,7 @@ class ClassSpec(Spec):
             self.LOG = zplog
         self.zenpack = zenpack
         self.name = name
+        self.symbol_name = get_symbol_name(self.zenpack.name, self.name)
 
         # Verify that bases is a tuple of base types.
         if isinstance(base, (tuple, list, set)):
@@ -239,11 +250,16 @@ class ClassSpec(Spec):
         else:
             self.order = 5 + (max(0, min(100, order)) / 100.0)
 
-        # Properties.
+        # save property defaults so they can be reapplied later
+        if properties:
+            self._property_defaults = properties.get('DEFAULTS', {})
+
         self.properties = self.specs_from_param(
             ClassPropertySpec, 'properties', properties, zplog=self.LOG)
 
-        # Relationships.
+        # Relationships
+        # If these exist, they will refer to relationship display properties, but won't have a schema
+        # defined (yet).  The schema is added later
         self.relationships = self.specs_from_param(
             ClassRelationshipSpec, 'relationships', relationships, zplog=self.LOG)
 
@@ -331,6 +347,114 @@ class ClassSpec(Spec):
                 self.path_pattern_streams.append(pattern_stream)
         else:
             self.extra_paths = []
+
+    def check_ancestor_properties(self, spec_name):
+        """Update any inheritable properties from ancestor"""
+        base_spec = self.zenpack.classes.get(spec_name)
+        for prop_name, prop_spec in base_spec.properties.items():
+            # if we don't have it, create our own copy
+            if prop_name not in self.properties:
+                self.properties[prop_name] = copy.copy(prop_spec)
+                this_prop_spec = self.properties[prop_name]
+                this_prop_spec.class_spec = self
+
+                # override any inherited properties with properties DEFAULTS
+                for k, v in self._property_defaults.items():
+                    # avoid unwanted keys like _source_location
+                    if k not in this_prop_spec.init_params.keys():
+                        continue
+                    setattr(this_prop_spec, k, v)
+
+    def update_inherited_property_parameters(self):
+        """ Update properties and property parameters from ancestors """
+        # Retrieve missing properties from bases
+        for base_name in self.get_base_specs():
+            self.check_ancestor_properties(base_name)
+
+        # For existing, update any inheritable property parameters
+        for prop_spec in self.properties.values():
+            prop_spec.update_inherited_params()
+
+    def plumb_class_relations(self):
+        """
+            Plumb class relations and update 
+            remote class _v_local_relations/_relations
+            as well as updating NEW_RELATIONS and NEW_COMPONENT_TYPES
+        """
+        if not self._plumbed:
+            for relname, relationship in self.relationships.iteritems():
+                # if no schema was ever allocated, remove this relationship from the class
+                # this happens if the ClassSpec sets display properties for a nonexistent relation
+                if not relationship.schema:
+                    self.LOG.error("Removing invalid display config for relationship {} from  {}.{}".format(
+                                relname, self.zenpack.name, self.name))
+                    self.relationships.pop(relname)
+                    continue
+                relationship.plumb()
+            self._plumbed = True
+
+    def update_inherited_relation_parameters(self):
+        """inherit parent relationship properties if not overridden locally"""
+        for rel_spec in self.relationships.values():
+            rel_spec.update_inherited_params()
+
+    def update_child_relations(self, relname):
+        """ Update relationships with any that 
+            should be inherited from base classes
+        """
+        # process descendants first
+        for d in self.get_descendant_specs():
+            self.zenpack.classes.get(d).update_child_relations(relname)
+
+        # find this relation
+        found_rel = self.find_relation_in_base_specs(relname)
+        if found_rel:
+            # add if it's not already here
+            if relname not in self.relationships:
+                self.relationships[relname] = found_rel
+            else:
+                # otherwise ensure it has a schema
+                if not self.relationships[relname].schema:
+                    self.relationships[relname].schema = found_rel.schema
+
+    def find_property_in_base_specs(self, propname):
+        '''return nearest inherited ClassPropertySpec'''
+        base_specs = self.get_base_specs()
+        for base in base_specs:
+            base_cls = self.zenpack.classes.get(base)
+            if propname in base_cls.properties:
+                return base_cls.properties.get(propname)
+        return None
+
+    def find_relation_in_base_specs(self, relname):
+        '''return nearest inherited RelationshipSpec'''
+        base_specs = self.get_base_specs()
+        for base in base_specs:
+            base_cls = self.zenpack.classes.get(base)
+            if relname in base_cls.relationships:
+                return base_cls.relationships.get(relname)
+        return None
+
+    def get_base_specs(self, bases=None):
+        '''Return ClassSpec bases in order of nearest proximity'''
+        if not bases:
+            bases = []
+        for base in self.bases:
+            base_cls = self.zenpack.classes.get(base)
+            if not base_cls:
+                continue
+            if base not in bases:
+                bases.append(base)
+            bases = base_cls.get_base_specs(bases)
+        return bases
+
+    def get_descendant_specs(self):
+        """Return ClassSpec descendants of this class"""
+        descendents = []
+        for cls in self.zenpack.classes.values():
+            if self.name in cls.bases:
+                descendents.append(cls.name)
+        return descendents
 
     @property
     @memoize
@@ -423,20 +547,6 @@ class ClassSpec(Spec):
         """Return True if this class is a subclass of type_."""
         return issubclass(self.model_schema_class, type_)
 
-    def get_info_base(self):
-        """Return appropriate info class"""
-        for cls, map in schema_map.items():
-            if self.is_a(cls):
-                return map.get('info', InfoBase)
-        return InfoBase
-
-    def get_interfaces_base(self):
-        """Return appropriate interfaces class"""
-        for cls, map in schema_map.items():
-            if self.is_a(cls):
-                return map.get('interface', IInfo)
-        return IInfo
-
     @property
     def is_device(self):
         """Return True if this class is a Device."""
@@ -444,30 +554,13 @@ class ClassSpec(Spec):
 
     @property
     def is_component(self):
-        """
-            **Deprecated
-            Return True if this class is a Component.
-        """
-
+        """Return True if this class is a Component."""
         return self.is_a(Component)
 
     @property
     def is_hardware_component(self):
-        """
-            **Deprecated
-            Return True if this class is a HWComponent.
-        """
-        return self.is_a(HWComponent)
-
-    @property
-    def is_a_component(self):
-        """Return True if this class is a component class."""
-        for cls in schema_map.keys():
-            if cls == Device or cls == Service:
-                continue
-            if self.is_a(cls):
-                return True
-        return False
+        """Return True if this class is a HardwareComponent."""
+        return self.is_a(HardwareComponent)
 
     @property
     def icon_url(self):
@@ -530,8 +623,7 @@ class ClassSpec(Spec):
         properties = []
         relations = []
         templates = []
-        device_catalogs = {}
-        global_catalogs = {}
+        catalogs = {}
 
         # First inherit from bases.
         for base in self.resolved_bases:
@@ -539,10 +631,13 @@ class ClassSpec(Spec):
                 properties.extend(base._properties)
             if hasattr(base, '_templates'):
                 templates.extend(base._templates)
-            if hasattr(base, '_device_catalogs'):
-                device_catalogs.update(base._device_catalogs)
-            if hasattr(base, '_global_catalogs'):
-                global_catalogs.update(base._global_catalogs)
+            if hasattr(base, '_catalogs'):
+                catalogs.update(base._catalogs)
+
+        if self.name not in catalogs:
+            catalogs[self.name] = {'indexes': {}}
+
+        indexes = catalogs[self.name]['indexes']
 
         # Add local properties and catalog indexes.
         for name, spec in self.properties.iteritems():
@@ -580,22 +675,13 @@ class ClassSpec(Spec):
             if spec.ofs_dict:
                 properties.append(spec.ofs_dict)
 
-            # Add class and instance catalogs.
-            for index_name, index_spec in spec.catalog_indexes.iteritems():
-                index_scope = index_spec.get('scope', 'device')
-                index_type = index_spec.get('type', 'field')
+            indexes.update(spec.catalog_indexes)
 
-                if index_scope in ('both', 'device'):
-                    if self.name in device_catalogs:
-                        device_catalogs[self.name][index_name] = index_type
-                    else:
-                        device_catalogs[self.name] = {index_name: index_type}
-
-                if index_scope in ('both', 'global'):
-                    if self.name in global_catalogs:
-                        global_catalogs[self.name][index_name] = index_type
-                    else:
-                        global_catalogs[self.name] = {index_name: index_type}
+        # Add a properly-scoped "id" index if needed
+        if len(indexes) > 0:
+            scopes = {x.get('scope', 'device') for x in indexes.values()}
+            indexes['id'] = {'type': 'field',
+                             'scope': 'device' if 'device' in scopes else 'global'}
 
         # Add local relations.
         for name, spec in self.relationships.iteritems():
@@ -613,8 +699,7 @@ class ClassSpec(Spec):
         attributes['_properties'] = tuple(properties)
         attributes['_v_local_relations'] = tuple(relations)
         attributes['_templates'] = tuple(templates)
-        attributes['_device_catalogs'] = device_catalogs
-        attributes['_global_catalogs'] = global_catalogs
+        attributes['_catalogs'] = catalogs
 
         # Add Impact stuff.
         attributes['impacts'] = self.impacts
@@ -660,7 +745,14 @@ class ClassSpec(Spec):
                 bases.append(self.zenpack.classes[base_classname].iinfo_class)
 
         if not bases:
-            bases = [self.get_interfaces_base()]
+            if self.is_device:
+                bases = [IDeviceInfo]
+            elif self.is_component:
+                bases = [IComponentInfo]
+            elif self.is_hardware_component:
+                bases = [IHardwareComponentInfo]
+            else:
+                bases = [IInfo]
 
         attributes = {}
 
@@ -718,10 +810,18 @@ class ClassSpec(Spec):
         attributes = {}
 
         if not bases:
-            bases = [self.get_info_base()]
             if self.is_device:
+                bases = [DeviceInfo]
+
                 # Override how status is determined for devices.
                 attributes["status"] = DeviceInfoStatusProperty()
+
+            elif self.is_component:
+                bases = [ComponentInfo]
+            elif self.is_hardware_component:
+                bases = [HardwareComponentInfo]
+            else:
+                bases = [InfoBase]
 
         attributes.update({
             'class_label': ProxyProperty('class_label'),
@@ -807,7 +907,7 @@ class ClassSpec(Spec):
 
     def create_registered(self):
         GSM.registerAdapter(self.info_class, (self.model_class,), self.iinfo_class)
-        if self.is_a_component:
+        if self.is_component or self.is_hardware_component:
             GSM.registerAdapter(self.formbuilder_class, (self.info_class,), IFormBuilder)
         self.register_dynamicview_adapters()
         self.register_impact_adapters()

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -236,6 +236,18 @@ class Spec(object):
 
         return specs
 
+    def get_custom_params(self):
+        """ Return dictionary of attributes that deviate
+            from class defaults
+        """
+        params = {}
+        for k, v in self.init_params.items():
+            val = getattr(self, k, None)
+            default = v.get('default', None)
+            if val != default:
+                params[k] = val
+        return params
+
     @ClassProperty
     @classmethod
     def init_params(cls):

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_inherited_properties.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_inherited_properties.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    Test the proper handling of inherited ClassSpec properties 
+"""
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+# stdlib Imports
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+# zenpacklib Imports
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
+
+YAML_DOC = """
+name: ZenPacks.zenoss.BasicZenPack
+class_relationships:
+- BasicDevice 1:MC BasicComponent
+classes:
+  BasicDevice:
+    base: [zenpacklib.Device]
+  BasicComponent:
+    base: [zenpacklib.Component]
+    properties:
+      hello_world:
+        label: Hello World
+        api_only: true
+        api_backendtype: method
+        grid_display: true
+  SubComponent:
+    base: [BasicComponent]
+    properties:
+      DEFAULTS:
+        grid_display: false
+      sub_test:
+        label: SubComponent Test 
+  AuxComponent:
+    base: [SubComponent]
+    properties:
+      aux_test:
+        label: AuxComponent Test
+      hello_world:
+        label: Aux Hello
+"""
+
+
+class TestInheritedProperties(BaseTestCase):
+    """
+        Test the proper handling of inherited ClassSpec properties 
+    """
+
+    def test_inherited_properties_display(self):
+        z = ZPLTestHarness(YAML_DOC)
+
+        base = z.cfg.classes.get('BasicComponent')
+        sub = z.cfg.classes.get('SubComponent')
+        aux = z.cfg.classes.get('AuxComponent')
+
+        # make sure the expected properties exist
+        self.properties_exist(base, ['hello_world'])
+        self.properties_exist(sub, ['sub_test', 'hello_world'])
+        self.properties_exist(aux, ['aux_test', 'hello_world', 'sub_test'])
+
+        self.property_value(base, 'hello_world', 'label', 'Hello World')
+        self.property_value(sub, 'hello_world', 'label', 'Hello World')
+        self.property_value(aux, 'hello_world', 'label', 'Aux Hello')
+
+        self.property_value(base, 'hello_world', 'api_only', True)
+        self.property_value(sub, 'hello_world', 'api_only', True)
+        self.property_value(aux, 'hello_world', 'api_only', True)
+
+        self.property_value(base, 'hello_world', 'api_backendtype', 'method')
+        self.property_value(sub, 'hello_world', 'api_backendtype', 'method')
+        self.property_value(aux, 'hello_world', 'api_backendtype', 'method')
+
+        self.property_value(base, 'hello_world', 'grid_display', True)
+        self.property_value(sub, 'hello_world', 'grid_display', False)
+        self.property_value(aux, 'hello_world', 'grid_display', False)
+
+        self.property_value(sub, 'sub_test', 'grid_display', False)
+        self.property_value(aux, 'sub_test', 'grid_display', False)
+
+        self.property_value(sub, 'sub_test', 'label', 'SubComponent Test')
+        self.property_value(aux, 'sub_test', 'label', 'SubComponent Test')
+
+        self.property_value(aux, 'aux_test', 'grid_display', True)
+
+
+    def property_value(self, spec, prop_name, attr_name, expected):
+        prop = spec.properties.get(prop_name)
+        actual = getattr(prop, attr_name, None)
+        self.assertEquals(expected, actual,
+                          '{} has unexpected value for "{}", expected: {}, actual: {}'.format(
+                          spec.name, prop_name, expected, actual)
+                          )
+
+    def properties_exist(self, spec, expected):
+        """confirm expected properties exist"""
+        actual = spec.properties.keys()
+        self.assertEquals(expected,
+                          actual,
+                          '{} properties expected: {}, actual: {}'.format(spec.name,
+                                                                          expected,
+                                                                          actual))
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestInheritedProperties))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_inherited_relations.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_inherited_relations.py
@@ -27,7 +27,7 @@ from ZenPacks.zenoss.ZenPackLib import zenpacklib
 
 
 
-YAML_DOC="""
+YAML_DOC = """
 name: ZenPacks.zenoss.OpenStackInfrastructure
 zProperties:
   DEFAULTS:
@@ -45,7 +45,7 @@ classes:
     base: [zenpacklib.Component]
     relationships:
       endpoint:
-        grid_display: True
+        grid_display: true
         label: Endpoint
   OrgComponent:
     base: [OpenstackComponent]
@@ -66,9 +66,11 @@ classes:
     label: Availability Zone
     order: 2
     relationships:
+      parentOrg:
+        label: Parent
       childOrgs:
-        grid_display: False
-        details_display: False
+        grid_display: false
+        details_display: false
 """
 
 
@@ -80,9 +82,40 @@ class TestZen23763(BaseTestCase):
 
     def test_inherited_relation_display(self):
         CFG = zenpacklib.load_yaml(YAML_DOC)
+        comp = CFG.classes.get('OpenstackComponent')
+        org = CFG.classes.get('OrgComponent')
         az = CFG.classes.get('AvailabilityZone')
-        rel = az.relationships.get('parentOrg')
-        self.assertEquals(rel.label, 'Parent Region', 'Inherited relation display properties failed')
+
+        self.property_value(comp, 'endpoint', 'grid_display', True)
+        self.property_value(comp, 'endpoint', 'label', 'Endpoint')
+        self.property_value(org, 'endpoint', 'grid_display', True)
+        self.property_value(org, 'endpoint', 'label', 'Endpoint')
+        self.property_value(az, 'endpoint', 'grid_display', True)
+        self.property_value(az, 'endpoint', 'label', 'Endpoint')
+
+        self.property_value(org, 'parentOrg', 'grid_display', True)
+        self.property_value(org, 'parentOrg', 'label', 'Parent Region')
+        self.property_value(org, 'parentOrg', 'label_width', 60)
+
+        self.property_value(az, 'parentOrg', 'grid_display', True)
+        self.property_value(az, 'parentOrg', 'label', 'Parent')
+        self.property_value(az, 'parentOrg', 'label_width', 60)
+
+        self.property_value(org, 'childOrgs', 'grid_display', True)
+        self.property_value(org, 'childOrgs', 'label', 'Children')
+        self.property_value(org, 'childOrgs', 'label_width', 60)
+
+        self.property_value(az, 'childOrgs', 'grid_display', False)
+        self.property_value(az, 'childOrgs', 'label', 'Children')
+        self.property_value(az, 'childOrgs', 'label_width', 60)
+
+    def property_value(self, spec, rel_name, attr_name, expected):
+        rel = spec.relationships.get(rel_name)
+        actual = getattr(rel, attr_name, None)
+        self.assertEquals(expected, actual,
+                          '{} has unexpected value for "{}", expected: {}, actual: {}'.format(
+                          spec.name, rel_name, expected, actual)
+                          )
 
 def test_suite():
     """Return test suite for this module."""


### PR DESCRIPTION
* Add "Relationship" type to handle input validation and relationship
class, cardinality, and name
* Prevent duplicate class_relationships spec building in
ZenPackSpecParams
* Moved majority of ZenPackSpec init method relationship handling to
ClassSpec, ClassRelationshipSpec, RelationshipSpec
* create ClassRelationshipSpec 'plumb' method to handle imported classes
handling
* Added ClassSpec 'plumb_class_relations' method to handle invalid
relationship detection and call to relationship 'plumb' method
* Added 'get_custom_params' to Spec
* Ensure class relationships are handled in order for inheritance
overrides
* Avoid premature calls to spec.model_class