### PR TITLE
Ensure correct Python types for validated input data (ZEN-26002)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
@@ -161,7 +161,7 @@ class GraphPointSpec(Spec):
         if self.cFunc is not None:
             graphpoint.cFunc = self.cFunc
         if self.color is not None:
-            graphpoint.color = self.color
+            graphpoint.color = str(self.color)
 
         if self.includeThresholds:
             thresh_gps = graph.addThresholdsForDataPoint(self.dpName)
@@ -174,5 +174,5 @@ class GraphPointSpec(Spec):
                 if legend:
                     thresh_gp.legend = legend
                 if color:
-                    thresh_gp.color = color
+                    thresh_gp.color = str(color)
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassSpec.py
@@ -142,7 +142,7 @@ class ProcessClassSpec(Spec):
             process_class.setZenProperty('zAlertOnRestart', self.alert_on_restart)
 
         if self.fail_severity is not None:
-            process_class.setZenProperty('zFailSeverity', self.fail_severity)
+            process_class.setZenProperty('zFailSeverity', int(self.fail_severity))
 
         if self.modeler_lock is not None:
             process_class.setZenProperty('zModelerLock', self.modeler_lock)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatasourceSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatasourceSpec.py
@@ -98,7 +98,7 @@ class RRDDatasourceSpec(Spec):
         if self.eventKey is not None:
             datasource.eventKey = self.eventKey
         if self.severity is not None:
-            datasource.severity = self.severity
+            datasource.severity = int(self.severity)
         if self.commandTemplate is not None:
             datasource.commandTemplate = self.commandTemplate
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDThresholdSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDThresholdSpec.py
@@ -83,7 +83,7 @@ class RRDThresholdSpec(Spec):
         if self.eventClass is not None:
             threshold.eventClass = self.eventClass
         if self.severity is not None:
-            threshold.severity = self.severity
+            threshold.severity = int(self.severity)
         if self.enabled is not None:
             threshold.enabled = self.enabled
         if self.extra_params:


### PR DESCRIPTION
- Fixes ZEN-26002
- Ensure that created object (datasources, thresholds, etc) attribute
values like severity and color are basic Python types (int, str) and not
their ZPL-subclassed equivalents (Severity, Color)