### PR TITLE
Various Unit Test cleanup, fixes (ZEN-26001)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/tests/test_catalog_scopes.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_catalog_scopes.py
@@ -9,10 +9,7 @@
 #
 ##############################################################################
 
-""" Multi-YAML import load
-
-Tests YAML loading from multiple files
-
+""" Test Catalog Scope (ZEN-18269)
 """
 # Zenoss Imports
 import Globals  # noqa
@@ -73,17 +70,18 @@ class TestCatalogScope(BaseTestCase):
 
     def test_catalog_specs(self):
         ''''''
-        data = {'DeviceIndexedComponent': {'device'},
-                'GlobalIndexedComponent': {'global'},
-                'GlobalAndDeviceIndexedComponent': {'device', 'global'},
+        data = {'DeviceIndexedComponent': ['device_idx'],
+                'GlobalIndexedComponent': ['global_idx'],
+                'GlobalAndDeviceIndexedComponent': ['device_idx', 'global_idx'],
                 }
         for name, expected in data.items():
             actual = self.get_scope(name)
+
             self.assertEqual(actual, expected, 'Expected catalog scope {}, got {} for {}'.format(expected, actual, name))
 
     def get_scope(self, name):
         ob = self.Z.build_ob(name)
-        return ob.get_catalog_scopes(name)
+        return ob._device_catalogs.get(name, {}).keys() + ob._global_catalogs.get(name, {}).keys()
 
 
 def test_suite():

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_class_proxies.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_class_proxies.py
@@ -12,9 +12,6 @@
 """Class proxy tests."""
 
 # stdlib Imports
-import os
-import site
-import tempfile
 import traceback
 
 # Zope Imports
@@ -22,6 +19,8 @@ from zope.event import notify
 
 # Zenoss Imports
 import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
 
 from Products.DataCollector.ApplyDataMap import ApplyDataMap
 from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_datasource_datapoint_consistency.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_datasource_datapoint_consistency.py
@@ -21,8 +21,7 @@ unused(Globals)
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 
 # zenpacklib Imports
-from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
-from ZenPacks.zenoss.ZenPackLib.tests.test_keywords import LOG, WarningLoader, LogCapture
+from ZenPacks.zenoss.ZenPackLib.tests.test_keywords import LogCapture
 
 # should be OK
 GOOD_YAML = """

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_extra_paths.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_extra_paths.py
@@ -25,10 +25,10 @@ from Products.ZenRelations.ToManyContRelationship import ToManyContRelationship
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 
 # zenpacklib Imports
-from ZenPacks.zenoss.ZenPackLib import zenpacklib
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
 
 
-YAML = """
+YAML_DOC = """
 name: ZenPacks.zenoss.SimplevSphere
 
 class_relationships:
@@ -77,6 +77,14 @@ classes:
 
 """
 
+simple_vsphere_zp = ZPLTestHarness(YAML_DOC)
+
+from ZenPacks.zenoss.SimplevSphere.Datacenter import Datacenter
+from ZenPacks.zenoss.SimplevSphere.Folder import Folder
+from ZenPacks.zenoss.SimplevSphere.Cluster import Cluster
+from ZenPacks.zenoss.SimplevSphere.ResourcePool import ResourcePool
+from ZenPacks.zenoss.SimplevSphere.VirtualMachine import VirtualMachine
+
 
 # When a manually-created python object is first added to its container, we
 # need to reload it, as its in-memory representation is changed.
@@ -122,7 +130,7 @@ class TestExtraPaths(BaseTestCase):
         self.dmd.Devices.SimplevSphere._setProperty('zPythonClass', 'ZenPacks.zenoss.SimplevSphere.Endpoint')
 
         # Load the YAML
-        self.CFG = zenpacklib.load_yaml(YAML)
+        self.CFG = simple_vsphere_zp.cfg
 
         # And create the model.
         self._create_device()
@@ -132,12 +140,12 @@ class TestExtraPaths(BaseTestCase):
         ep = self.dmd.Devices.SimplevSphere.createInstance('testdevice')
 
         # Datacenter
-        from ZenPacks.zenoss.SimplevSphere.Datacenter import Datacenter
+
         datacenter = Datacenter("Datacenter")
         datacenter = addContained(ep, "datacenters", datacenter)  # link into endpoin
 
         # Create a couple of nested folders
-        from ZenPacks.zenoss.SimplevSphere.Folder import Folder
+
         folder_top = Folder("Folder-Top")
         folder_top = addContained(ep, "folders", folder_top)
 
@@ -146,13 +154,13 @@ class TestExtraPaths(BaseTestCase):
         folder_child = addNonContained(folder_top, "childFolders", folder_child)
 
         # A cluster
-        from ZenPacks.zenoss.SimplevSphere.Cluster import Cluster
+
         cluster = Cluster("Cluster")
         cluster = addContained(datacenter, "computeResources", cluster)  # link into DC
         cluster = addNonContained(folder_top, "childEntities", cluster)  # link into folder
 
         # And a couple of nested resource pools
-        from ZenPacks.zenoss.SimplevSphere.ResourcePool import ResourcePool
+
         cluster_rp = ResourcePool("ResourcePool-Top")
         cluster_rp = addContained(datacenter, "resourcePools", cluster_rp)
         cluster_rp = addNonContained(cluster, "resourcePools", cluster_rp)
@@ -164,8 +172,6 @@ class TestExtraPaths(BaseTestCase):
         cluster = addNonContained(sub_rp, "owner", cluster)
 
         # VMs
-        from ZenPacks.zenoss.SimplevSphere.VirtualMachine import VirtualMachine
-
         # One at the top level
         vm1 = VirtualMachine("VirtualMachine-1")
         vm1 = addContained(ep, "vms", vm1)

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_severity_validation.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_severity_validation.py
@@ -17,8 +17,6 @@ import yaml
 from ZenPacks.zenoss.ZenPackLib.lib.helpers.Loader import Loader
 from ZenPacks.zenoss.ZenPackLib.lib.helpers.Dumper import Dumper
 
-from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
-
 # Zenoss Imports
 import Globals  # noqa
 from Products.ZenUtils.Utils import unused

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_subcomponent_nav_js.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_subcomponent_nav_js.py
@@ -25,61 +25,17 @@ from Products.ZenTestCase.BaseTestCase import BaseTestCase
 # zenpacklib Imports
 from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
 
+def vsphere_installed():
+    """Return True if vSphere is installed"""
+    try:
+        from ZenPacks.zenoss.vSphere.Datacenter import Datacenter
+    except ImportError:
+        pass
+    else:
+        return True
+    return False
 
 YAML_DOC = """name: ZenPacks.zenoss.ZenPackLib
-zProperties:
-  DEFAULTS:
-    category: VMware vSphere
-  zVSphereEndpointHost:
-    type: string
-  zVSphereEndpointPort:
-    type: int
-    default: 443
-  zVSphereEndpointUser:
-    type: string
-    default: admin
-  zVSphereEndpointPassword:
-    type: password
-  zVSphereEndpointUseSsl:
-    type: boolean
-    default: True
-  zVSpherePerfDelayCollectionMinutes:
-    type: int
-  zVSpherePerfQueryChunkSize:
-    type: int
-    default: 250
-  zVSpherePerfQueryVcChunkSize:
-    type: int
-    default: 64
-  zVSpherePerfQueryRaw20:
-    type: boolean
-    default: True
-  zVSpherePerfQueryVcRaw20:
-    type: boolean
-    default: False
-  zVSpherePerfMaxAgeMinutes:
-    type: int
-    default: 28
-  zVSpherePerfRecoveryMinutes:
-    type: int
-    default: 240
-  zVSpherePerfParallelQueries:
-    type: int
-    default: 6
-  zVSpherePerfQueryTimeout:
-    type: int
-    default: 200
-  zVSphereModelIgnore:
-    type: lines
-  zVSphereModelCache:
-    type: lines
-  zVSphereHostSystemUser:
-    type: string
-    default: admin
-  zVSphereHostSystemPassword:
-    type: password
-  zVSphereHostCollectionClusterWhitelist:
-    type: lines
 class_relationships:
   - Endpoint 1:MC Datacenter
   - Endpoint 1:MC Folder
@@ -1042,16 +998,19 @@ class TestSubComponentNavJS(BaseTestCase):
 
     def test_nav_js(self):
         ''''''
-        z = ZPLTestHarness(YAML_DOC)
-        cls = z.cfg.classes.get('ResourcePool')
-        self.assertEquals(cls.subcomponent_nav_js_snippet,
-                          expected_rp,
-                          'Unexpected subcomponent_nav_js_snippet for ResourcePool')
+        if not vsphere_installed():
+            z = ZPLTestHarness(YAML_DOC)
+            cls = z.cfg.classes.get('ResourcePool')
+            self.assertEquals(cls.subcomponent_nav_js_snippet,
+                              expected_rp,
+                              'Unexpected subcomponent_nav_js_snippet for ResourcePool')
 
-        cls = z.cfg.classes.get('VirtualApp')
-        self.assertEquals(cls.subcomponent_nav_js_snippet,
-                          expected_va,
-                          'Unexpected subcomponent_nav_js_snippet for ResourcePool')
+            cls = z.cfg.classes.get('VirtualApp')
+            self.assertEquals(cls.subcomponent_nav_js_snippet,
+                              expected_va,
+                              'Unexpected subcomponent_nav_js_snippet for ResourcePool')
+        else:
+            print "TestSubComponentNavJS cannot run if ZenPacks.zenoss.vSphere is installed"
 
 def test_suite():
     """Return test suite for this module."""

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
@@ -24,9 +24,6 @@ from Products.ZenTestCase.BaseTestCase import BaseTestCase
 # zenpacklib Imports
 from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
 from ZenPacks.zenoss.ZenPackLib.lib.base.ZenPack import ZenPack
-from ZenPacks.zenoss.ZenPackLib.lib.params.RRDTemplateSpecParams import RRDTemplateSpecParams
-from ZenPacks.zenoss.ZenPackLib.lib.helpers.Dumper import Dumper
-from ZenPacks.zenoss.ZenPackLib.lib.helpers.Loader import Loader
 
 
 YAML_DOC = """name: ZenPacks.zenoss.ZenPackLib


### PR DESCRIPTION
- Fixes ZEN-26001
- Reduce logging verbosity in ZPLTestHarness
- added "get_templates" method to pre-fetch templates during testing
- update check_templates_vs_spec and check_templates_vs_yaml to use
prefetched templates
- misc pep8
- renamed test_multi_file_yaml_load.py to test_catalog_scopes.py
- revised test_catalog_scopes in light of prior CatalogBase changes
- removed unused imports from various tests
- revised test_extra_paths to utilize ZPLTestHarness
- renamed test_zen_25487.py to test_subcomponent_nav_js
- updated test_subcomponent_nav_js to only run if vSphere zenpack is not
installed.