### PR TITLE
 Revise Relationship and Property building and inheritance handling

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
@@ -1,6 +1,49 @@
 from ..helpers.ZenPackLibLog import DEFAULTLOG as LOG
-
 import string
+from Products.ZenRelations.RelSchema import ToMany, ToManyCont, ToOne
+
+
+class Relationship(str):
+    cls = None
+    name = None
+    cardinality = None
+
+    _relTypeCardinality = {
+        'ToOne': '1',
+        'ToMany': 'M',
+        'ToManyCont': 'MC'
+    }
+
+    _relTypeClasses = {
+        "ToOne": ToOne,
+        "ToMany": ToMany,
+        "ToManyCont": ToManyCont
+    }
+
+    _relTypeNames = {
+        ToOne: "ToOne",
+        ToMany: "ToMany",
+        ToManyCont: "ToManyCont"
+    }
+
+    def __new__(cls, value):
+        return str.__new__(cls, cls.validate(value))
+
+    @classmethod
+    def validate(cls, value):
+        if not value:
+            raise ValueError('Relationship cannot be None')
+        if not isinstance(value, str):
+            raise ValueError('Invalid type ({}) given for Relationship'.format(type(value)))
+        if value not in ['ToOne', 'ToMany', 'ToManyCont']:
+            raise ValueError('Invalid value ({}) given for Relationship'.format(value))
+        return value
+
+    def __init__(self, value):
+        self.name = value
+        self.cls = self._relTypeClasses.get(value)
+        self.cardinality = self._relTypeCardinality.get(value)
+
 
 class Color(str):
     """Hexadecimal string representation for color"""

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
@@ -15,7 +15,7 @@ import keyword
 from collections import OrderedDict
 from ..functions import ZENOSS_KEYWORDS, JS_WORDS, relname_from_classname, find_keyword_cls
 from .ZenPackLibLog import ZPLOG, DEFAULTLOG
-from ..base.types import Color, Severity
+from ..base.types import Severity
 
 
 class Loader(yaml.Loader):

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
@@ -7,7 +7,6 @@
 #
 ##############################################################################
 import os
-import logging
 from collections import OrderedDict
 import yaml
 import time

--- a/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
@@ -8,8 +8,6 @@
 ##############################################################################
 import os
 import os.path
-import re
-import inspect
 import sys
 import yaml
 import collections
@@ -20,17 +18,13 @@ import Globals
 from Products.ZenUtils.Utils import unused
 
 from Acquisition import aq_base
-from Products.ZenModel.ZenPack import ZenPack
 from Products.ZenUtils.ZenScriptBase import ZenScriptBase
 
-from ..functions import create_module
 from ..params.ZenPackSpecParams import ZenPackSpecParams
-from ..params.DeviceClassSpecParams import DeviceClassSpecParams
 from ..params.RRDTemplateSpecParams import RRDTemplateSpecParams
 from ..params.EventClassSpecParams import EventClassSpecParams
 from ..params.EventClassMappingSpecParams import EventClassMappingSpecParams
 from ..params.ProcessClassOrganizerSpecParams import ProcessClassOrganizerSpecParams
-from ..params.ProcessClassSpecParams import ProcessClassSpecParams
 from ..resources.templates import SETUP_PY
 from ..helpers.ZenPackLibLog import ZenPackLibLog, DEFAULTLOG
 from ..helpers.WarningLoader import WarningLoader
@@ -113,7 +107,7 @@ class ZPLCommand(ZenScriptBase):
             )
         else:
             try:
-                file = open(self.options.filename)
+                open(self.options.filename)
                 valid = True
             except IOError as e:
                 errorMessage = ('WARN: unable to read file {filename} '

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
@@ -12,7 +12,6 @@ from .ClassSpecParams import ClassSpecParams
 from .DeviceClassSpecParams import DeviceClassSpecParams
 from .EventClassSpecParams import EventClassSpecParams
 from .ProcessClassOrganizerSpecParams import ProcessClassOrganizerSpecParams
-from ..spec.RelationshipSchemaSpec import RelationshipSchemaSpec
 from ..spec.ZenPackSpec import ZenPackSpec
 
 
@@ -32,17 +31,10 @@ class ZenPackSpecParams(SpecParams, ZenPackSpec):
         self.zProperties = self.specs_from_param(
             ZPropertySpecParams, 'zProperties', zProperties, leave_defaults=True, zplog=self.LOG)
 
-        self.class_relationships = []
-        if class_relationships:
-            if not isinstance(class_relationships, list):
-                raise ValueError("class_relationships must be a list, not a %s" % type(class_relationships))
-
-            for rel in class_relationships:
-                rel['zplog'] = self.LOG
-                self.class_relationships.append(RelationshipSchemaSpec(self, **rel))
-
         self.classes = self.specs_from_param(
             ClassSpecParams, 'classes', classes, leave_defaults=True, zplog=self.LOG)
+
+        self.class_relationships = class_relationships
 
         self.device_classes = self.specs_from_param(
             DeviceClassSpecParams, 'device_classes', device_classes, leave_defaults=True, zplog=self.LOG)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
@@ -156,6 +156,16 @@ class ClassPropertySpec(Spec):
         else:
             self.order = 4 + (max(0, min(100, order)) / 100.0)
 
+    def update_inherited_params(self):
+        """Copy any inherited parameters if they are not default or already specified here"""
+        custom = self.get_custom_params()
+        prop_spec = self.class_spec.find_property_in_base_specs(self.name)
+        if not prop_spec:
+            return
+        for k, v in prop_spec.get_custom_params().items():
+            if k not in custom:
+                setattr(self, k, v)
+
     @property
     def ofs_dict(self):
         """Return OFS _properties dictionary."""

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RelationshipSchemaSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RelationshipSchemaSpec.py
@@ -6,14 +6,20 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-from Products.ZenRelations.RelSchema import ToMany, ToManyCont, ToOne
 from Products.ZenRelations.Exceptions import ZenSchemaError
 from ..functions import relname_from_classname
 from .Spec import Spec
+from .ClassRelationshipSpec import ClassRelationshipSpec
 
+from ..base.types import Relationship
+from Products.ZenUtils.Utils import monkeypatch, importClass
 
 class RelationshipSchemaSpec(Spec):
     """RelationshipSchemaSpec"""
+    _left_schema = None
+    _right_schema = None
+    _left_type = None
+    _right_type = None
 
     def __init__(
         self,
@@ -53,12 +59,82 @@ class RelationshipSchemaSpec(Spec):
             raise ZenSchemaError("In %s(%s) - (%s)%s, invalid orientation- left and right may be reversed." % (left_class, left_relname, right_relname, right_class))
 
         self.zenpack_spec = zenpack_spec
+        self.left_rel = Relationship(left_type)
         self.left_class = left_class
         self.left_relname = left_relname
-        self.left_schema = self.make_schema(left_type, right_type, right_class, right_relname)
+        self.left_spec = self.zenpack_spec.classes.get(self.left_class)
+        # if spec is not provded, import the target class
+        if not self.left_spec:
+            self.get_imported_class(self.left_class)
+
+        self.right_rel = Relationship(right_type)
         self.right_class = right_class
         self.right_relname = right_relname
-        self.right_schema = self.make_schema(right_type, left_type, left_class, left_relname)
+        self.right_spec = self.zenpack_spec.classes.get(self.right_class)
+        # if spec is not provded, import the target class
+        if not self.right_spec:
+            self.get_imported_class(self.right_class)
+
+        # update ClassRelationshipSpec or imported class
+        self.update_class_relationship_spec(self.left_spec, self.left_relname, self.left_schema, self.left_class)
+        self.update_class_relationship_spec(self.right_spec, self.right_relname, self.right_schema, self.right_class)
+
+    def get_imported_class(self, classname):
+        """import target class by reference"""
+        # this might be provided by the ZenPack but not defined in the YAML
+        if '.' not in classname:
+            classname = '{}.{}.{}'.format(self.zenpack_spec.name, classname, classname)
+        if '.' in classname and classname.split('.')[-1] not in self.zenpack_spec.classes:
+            module = ".".join(classname.split('.')[0:-1])
+            try:
+                kls = importClass(module)
+                self.zenpack_spec.imported_classes[classname] = kls
+            except ImportError as e:
+                self.LOG.error('Failed to import class {} from {} ({})'.format(classname, module, e))
+                pass
+
+    def update_children(self):
+        """update child classes of this relationship's target specs"""
+        spec_map = {self.left_relname: self.left_spec,
+                    self.right_relname: self.right_spec}
+        for relname, spec in spec_map.items():
+            # skip if this is an imported class
+            if not spec:
+                continue
+            spec.update_child_relations(relname)
+
+    def update_class_relationship_spec(self, spec, relname, schema, classname):
+        """Add or Update ClassRelationshipSpec based on this RelationshipSpec"""
+        if spec:
+            # this shouldn't happen
+            if not schema:
+                self.LOG.error('Schema relation not provided for {} ({})'.format(spec, relname))
+                return
+            # ClassRelationshipSpec may exist already if relationships property overrides were
+            # specified in the YAML, but they won't have a schema since it wasn't
+            # created yet
+            if relname in spec.relationships:
+                rel_spec = spec.relationships[relname]
+                if not rel_spec.schema:
+                    rel_spec.schema = schema
+            # Otherwise we create it now with defaults
+            else:
+                spec.relationships[relname] = ClassRelationshipSpec(spec, relname, schema)
+        # if ClassSpec doesn't exist, then we are modifying an imported class
+        else:
+            kls = self.zenpack_spec.imported_classes.get(classname)
+            if kls:
+                if relname not in (x[0] for x in kls._relations):
+                    rel = ((relname, schema.__class__(schema.remoteType,
+                                                      schema.remoteClass,
+                                                      schema.remoteName)),)
+                    # avoid modifying _relations if this is a ZPL-derived class
+                    if hasattr(kls, '_v_local_relations'):
+                        kls._v_local_relations += rel
+                    else:
+                        kls._relations += rel
+            else:
+                self.LOG.error('Failed to add relationship ({}) to imported class ({}).'.format(relname, classname))
 
     @classmethod
     def valid_orientation(cls, left_type, right_type):
@@ -85,39 +161,33 @@ class RelationshipSchemaSpec(Spec):
 
         return False
 
-    _relTypeCardinality = {
-        ToOne: '1',
-        ToMany: 'M',
-        ToManyCont: 'MC'
-    }
-
-    _relTypeClasses = {
-        "ToOne": ToOne,
-        "ToMany": ToMany,
-        "ToManyCont": ToManyCont
-    }
-
-    _relTypeNames = {
-        ToOne: "ToOne",
-        ToMany: "ToMany",
-        ToManyCont: "ToManyCont"
-    }
-
     @property
     def left_type(self):
-        return self._relTypeNames.get(self.right_schema.__class__)
+        if not self._left_type:
+            self._left_type = self.left_rel.name
+        return self._left_type
+
+    @left_type.setter
+    def left_type(self, value):
+        pass
 
     @property
     def right_type(self):
-        return self._relTypeNames.get(self.left_schema.__class__)
+        if not self._right_type:
+            self._right_type = self.right_rel.name
+        return self._right_type
+
+    @right_type.setter
+    def right_type(self, value):
+        pass
 
     @property
     def left_cardinality(self):
-        return self._relTypeCardinality.get(self.right_schema.__class__)
+        return self.right_rel.cardinality
 
     @property
     def right_cardinality(self):
-        return self._relTypeCardinality.get(self.left_schema.__class__)
+        return self.left_rel.cardinality
 
     @property
     def default_left_relname(self):
@@ -131,21 +201,22 @@ class RelationshipSchemaSpec(Spec):
     def cardinality(self):
         return '%s:%s' % (self.left_cardinality, self.right_cardinality)
 
-    def make_schema(self, relTypeName, remoteRelTypeName, remoteClass, remoteName):
-        relType = self._relTypeClasses.get(relTypeName, None)
-        if not relType:
-            raise ValueError("Unrecognized Relationship Type '%s'" % relTypeName)
+    @property
+    def left_schema(self):
+        if not self._left_schema:
+            self._left_schema = self.left_rel.cls(self.right_rel.cls, self.right_class, self.right_relname)
+            self.qualify_remote_class(self._left_schema)
+        return self._left_schema
 
-        remoteRelType = self._relTypeClasses.get(remoteRelTypeName, None)
-        if not remoteRelType:
-            raise ValueError("Unrecognized Relationship Type '%s'" % remoteRelTypeName)
+    @property
+    def right_schema(self):
+        if not self._right_schema:
+            self._right_schema = self.right_rel.cls(self.left_rel.cls, self.left_class, self.left_relname)
+            self.qualify_remote_class(self._right_schema)
+        return self._right_schema
 
-        schema = relType(remoteRelType, remoteClass, remoteName)
-
-        # Qualify unqualified classnames.
+    def qualify_remote_class(self, schema):
+        """Qualify unqualified classnames"""
         if '.' not in schema.remoteClass:
             schema.remoteClass = '{}.{}'.format(
                 self.zenpack_spec.name, schema.remoteClass)
-
-        return schema
-

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -236,6 +236,18 @@ class Spec(object):
 
         return specs
 
+    def get_custom_params(self):
+        """ Return dictionary of attributes that deviate
+            from class defaults
+        """
+        params = {}
+        for k, v in self.init_params.items():
+            val = getattr(self, k, None)
+            default = v.get('default', None)
+            if val != default:
+                params[k] = val
+        return params
+
     @ClassProperty
     @classmethod
     def init_params(cls):

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
@@ -12,7 +12,7 @@ import importlib
 import operator
 import types
 from Products.Five import zcml
-from Products.ZenUtils.Utils import monkeypatch, importClass
+from Products.ZenUtils.Utils import monkeypatch
 from Products.Zuul.routers.device import DeviceRouter
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 from zope.viewlet.interfaces import IViewlet
@@ -28,7 +28,6 @@ from ..base.ZenPack import ZenPack
 from .Spec import Spec
 from .ClassSpec import ClassSpec
 from .DeviceClassSpec import DeviceClassSpec
-from .ClassRelationshipSpec import ClassRelationshipSpec
 from .RelationshipSchemaSpec import RelationshipSchemaSpec
 from .ZPropertySpec import ZPropertySpec
 from .EventClassSpec import EventClassSpec
@@ -92,6 +91,7 @@ class ZenPackSpec(Spec):
     _device_js_snippet = None
     _dynamicview_nav_js_snippet = None
     _zenpack_module = None
+    imported_classes = {}
 
     def __init__(
             self,
@@ -126,18 +126,6 @@ class ZenPackSpec(Spec):
         super(ZenPackSpec, self).__init__(_source_location=_source_location)
         if zplog:
             self.LOG = zplog
-        # The parameters from which this zenpackspec was originally
-        # instantiated.
-        from ..params.ZenPackSpecParams import ZenPackSpecParams
-        self.specparams = ZenPackSpecParams(
-            name,
-            zProperties=zProperties,
-            classes=classes,
-            class_relationships=class_relationships,
-            device_classes=device_classes,
-            event_classes=event_classes,
-            process_class_organizers=process_class_organizers,
-            zplog=self.LOG)
         self.name = name
         self.LOG.debug("------ {} ------".format(self.name))
         self.id_prefix = name.replace(".", "_")
@@ -149,6 +137,12 @@ class ZenPackSpec(Spec):
         self.zProperties = self.specs_from_param(
             ZPropertySpec, 'zProperties', zProperties, zplog=self.LOG)
 
+        # Classes
+        self.classes = self.specs_from_param(ClassSpec, 'classes', classes, zplog=self.LOG)
+
+        # update properties from ancestor classes
+        self.plumb_properties()
+
         # Class Relationship Schema
         self.class_relationships = []
         if class_relationships:
@@ -158,119 +152,12 @@ class ZenPackSpec(Spec):
                 rel['zplog'] = self.LOG
                 self.class_relationships.append(RelationshipSchemaSpec(self, **rel))
 
-        # Classes
-        self.classes = self.specs_from_param(ClassSpec, 'classes', classes, zplog=self.LOG)
-
-        self.imported_classes = {}
-
-        # Import any external classes referred to in the schema
+        # update relationships for ClassSpec child classes
         for rel in self.class_relationships:
-            for relschema in (rel.left_schema, rel.right_schema):
-                className = relschema.remoteClass
-                if '.' in className and className.split('.')[-1] not in self.classes:
-                    module = ".".join(className.split('.')[0:-1])
-                    try:
-                        kls = importClass(module)
-                        self.imported_classes[className] = kls
-                    except ImportError:
-                        pass
+            rel.update_children()
 
-        # Class Relationships
-        if classes:
-            for classname, classdata in classes.iteritems():
-                if 'relationships' not in classdata:
-                    classdata['relationships'] = []
-
-                relationships = classdata['relationships']
-                for relationship in relationships:
-                    # We do not allow the schema to be specified directly.
-                    if 'schema' in relationships[relationship]:
-                        raise ValueError("Class '%s': 'schema' may not be defined or modified in an individual class's relationship.  Use the zenpack's class_relationships instead." % classname)
-
-        def find_relation_in_bases(bases, relname):
-            '''return inherited relationship spec'''
-            for base in bases:
-                base_cls = self.classes.get(base)
-                if relname in base_cls.relationships:
-                    return base_cls.relationships.get(relname)
-            return None
-
-        def get_bases(cls, bases=[]):
-            '''find all available base classes for this class'''
-            for base in cls.bases:
-                base_cls = self.classes.get(base)
-                if not base_cls:
-                    continue
-                if base not in bases:
-                    bases.append(base)
-                bases = get_bases(base_cls, bases)
-            return bases
-
-        for class_ in self.classes.values():
-            # list of all base classes for this class
-            bases = get_bases(class_, bases=[])
-            # Link the appropriate predefined (class_relationships) schema into place on this class's relationships list.
-            for rel in self.class_relationships:
-                # handle both directions
-                for direction in ['left', 'right']:
-                    target_class = getattr(rel, '%s_class' % direction)
-                    target_relname = getattr(rel, '%s_relname' % direction)
-                    target_schema = getattr(rel, '%s_schema' % direction)
-                    # these are directly specified for the class in yaml
-                    if class_.name == target_class:
-                        if target_relname not in class_.relationships:
-                            class_.relationships[target_relname] = ClassRelationshipSpec(class_, target_relname)
-                        if not class_.relationships[target_relname].schema:
-                            class_.relationships[target_relname].schema = target_schema
-                    # look for relations inherited from base classes
-                    # go through these in order
-                    else:
-                        # these are in order from nearest to farthest
-                        for base in bases:
-                            if target_class == base:
-                                # see if we have an existing relspec
-                                found_rel = find_relation_in_bases(bases, target_relname)
-                                # we need to inherit in this case
-                                if found_rel:
-                                    if target_relname not in class_.relationships:
-                                        class_.relationships[target_relname] = found_rel
-                                    if not class_.relationships[target_relname].schema:
-                                        class_.relationships[target_relname].schema = target_schema
-                                    continue
-
-        for class_ in self.classes.values():
-            # Plumb _relations
-            for relname, relationship in class_.relationships.iteritems():
-                if not relationship.schema:
-                    self.LOG.error("Removing invalid display config for relationship {} from  {}.{}".format(relname, self.name, class_.name))
-                    class_.relationships.pop(relname)
-                    continue
-
-                if relationship.schema.remoteClass in self.imported_classes.keys():
-                    remoteClass = relationship.schema.remoteClass  # Products.ZenModel.Device.Device
-                    relname = relationship.schema.remoteName  # coolingFans
-                    modname = relationship.class_.model_class.__module__  # ZenPacks.zenoss.HP.Proliant.CoolingFan
-                    className = relationship.class_.model_class.__name__  # CoolingFan
-                    remoteClassObj = self.imported_classes[remoteClass]  # Device_obj
-                    remoteType = relationship.schema.remoteType  # ToManyCont
-                    localType = relationship.schema.__class__  # ToOne
-                    remote_relname = relationship.zenrelations_tuple[0]  # products_zenmodel_device_device
-
-                    if relname not in (x[0] for x in remoteClassObj._relations):
-                        rel = ((relname, remoteType(localType, modname, remote_relname)),)
-                        # do this differently if it's on a ZPL-based class
-                        if hasattr(remoteClassObj, '_v_local_relations'):
-                            remoteClassObj._v_local_relations += rel
-                        else:
-                            remoteClassObj._relations += rel
-
-                    remote_module_id = remoteClassObj.__module__
-                    if relname not in self.NEW_RELATIONS[remote_module_id]:
-                        self.NEW_RELATIONS[remote_module_id].append(relname)
-
-                    component_type = '.'.join((modname, className))
-                    if component_type not in self.NEW_COMPONENT_TYPES:
-                        self.NEW_COMPONENT_TYPES.append(component_type)
+        # update relations on imported classes
+        self.plumb_relations()
 
         # Device Classes
         self.device_classes = self.specs_from_param(
@@ -283,6 +170,41 @@ class ZenPackSpec(Spec):
         # Process Classes
         self.process_class_organizers = self.specs_from_param(
             ProcessClassOrganizerSpec, 'process_class_organizers', process_class_organizers)
+
+        # The parameters from which this zenpackspec was originally
+        # instantiated.
+        from ..params.ZenPackSpecParams import ZenPackSpecParams
+        self.specparams = ZenPackSpecParams(
+            name,
+            zProperties=zProperties,
+            classes=classes,
+            class_relationships=self.class_relationships,
+            device_classes=device_classes,
+            event_classes=event_classes,
+            process_class_organizers=process_class_organizers,
+            zplog=self.LOG)
+
+    def plumb_properties(self):
+        """
+            Plumb class properties by ancestors first
+        """
+        for class_ in self.classes.values():
+            for name in class_.get_base_specs():
+                spec = self.classes.get(name)
+                spec.update_inherited_property_parameters()
+            class_.update_inherited_property_parameters()
+
+    def plumb_relations(self):
+        """
+            Plumb class relations by ancestors first
+        """
+        for class_ in self.classes.values():
+            for name in class_.get_base_specs():
+                spec = self.classes.get(name)
+                spec.update_inherited_relation_parameters()
+                spec.plumb_class_relations()
+            class_.update_inherited_relation_parameters()
+            class_.plumb_class_relations()
 
     @property
     def ordered_classes(self):

--- a/ZenPacks/zenoss/ZenPackLib/lib/tests/TestCase.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/tests/TestCase.py
@@ -7,8 +7,6 @@
 #
 ##############################################################################
 import importlib
-import logging
-import sys
 from ..helpers.ZenPackLibLog import ZenPackLibLog, DEFAULTLOG
 
 

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_inherited_properties.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_inherited_properties.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    Test the proper handling of inherited ClassSpec properties 
+"""
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+# stdlib Imports
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+# zenpacklib Imports
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
+
+YAML_DOC = """
+name: ZenPacks.zenoss.BasicZenPack
+class_relationships:
+- BasicDevice 1:MC BasicComponent
+classes:
+  BasicDevice:
+    base: [zenpacklib.Device]
+  BasicComponent:
+    base: [zenpacklib.Component]
+    properties:
+      hello_world:
+        label: Hello World
+        api_only: true
+        api_backendtype: method
+        grid_display: true
+  SubComponent:
+    base: [BasicComponent]
+    properties:
+      DEFAULTS:
+        grid_display: false
+      sub_test:
+        label: SubComponent Test 
+  AuxComponent:
+    base: [SubComponent]
+    properties:
+      aux_test:
+        label: AuxComponent Test
+      hello_world:
+        label: Aux Hello
+"""
+
+
+class TestInheritedProperties(BaseTestCase):
+    """
+        Test the proper handling of inherited ClassSpec properties 
+    """
+
+    def test_inherited_properties_display(self):
+        z = ZPLTestHarness(YAML_DOC)
+
+        base = z.cfg.classes.get('BasicComponent')
+        sub = z.cfg.classes.get('SubComponent')
+        aux = z.cfg.classes.get('AuxComponent')
+
+        # make sure the expected properties exist
+        self.properties_exist(base, ['hello_world'])
+        self.properties_exist(sub, ['sub_test', 'hello_world'])
+        self.properties_exist(aux, ['aux_test', 'hello_world', 'sub_test'])
+
+        self.property_value(base, 'hello_world', 'label', 'Hello World')
+        self.property_value(sub, 'hello_world', 'label', 'Hello World')
+        self.property_value(aux, 'hello_world', 'label', 'Aux Hello')
+
+        self.property_value(base, 'hello_world', 'api_only', True)
+        self.property_value(sub, 'hello_world', 'api_only', True)
+        self.property_value(aux, 'hello_world', 'api_only', True)
+
+        self.property_value(base, 'hello_world', 'api_backendtype', 'method')
+        self.property_value(sub, 'hello_world', 'api_backendtype', 'method')
+        self.property_value(aux, 'hello_world', 'api_backendtype', 'method')
+
+        self.property_value(base, 'hello_world', 'grid_display', True)
+        self.property_value(sub, 'hello_world', 'grid_display', False)
+        self.property_value(aux, 'hello_world', 'grid_display', False)
+
+        self.property_value(sub, 'sub_test', 'grid_display', False)
+        self.property_value(aux, 'sub_test', 'grid_display', False)
+
+        self.property_value(sub, 'sub_test', 'label', 'SubComponent Test')
+        self.property_value(aux, 'sub_test', 'label', 'SubComponent Test')
+
+        self.property_value(aux, 'aux_test', 'grid_display', True)
+
+
+    def property_value(self, spec, prop_name, attr_name, expected):
+        prop = spec.properties.get(prop_name)
+        actual = getattr(prop, attr_name, None)
+        self.assertEquals(expected, actual,
+                          '{} has unexpected value for "{}", expected: {}, actual: {}'.format(
+                          spec.name, prop_name, expected, actual)
+                          )
+
+    def properties_exist(self, spec, expected):
+        """confirm expected properties exist"""
+        actual = spec.properties.keys()
+        self.assertEquals(expected,
+                          actual,
+                          '{} properties expected: {}, actual: {}'.format(spec.name,
+                                                                          expected,
+                                                                          actual))
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestInheritedProperties))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_inherited_relation_overrides.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_inherited_relation_overrides.py
@@ -62,7 +62,7 @@ classes:
     label: API Queue
 """
 
-EXPECTED = ["{id: 'RabbitMQAPI_Node',dataIndex: 'rabbitMQAPI_Node',header: _t('Node'),width: 100,renderer: Zenoss.render.zenpacklib_ZenPacks_zenoss_ZenPackLib_entityLinkFromGrid}"]
+EXPECTED = ["{id: 'RabbitMQAPI_Node',dataIndex: 'rabbitMQAPI_Node',header: _t('Node'),width: 100,renderer: Zenoss.render.zenpacklib_ZenPacks_zenoss_ZenPackLib_entityLinkFromGrid,sortable: true}"]
 
 class TestZen21966(BaseTestCase):
     """Test fix for ZEN-21966
@@ -73,7 +73,7 @@ class TestZen21966(BaseTestCase):
         z = ZPLTestHarness(YAML_DOC)
         cls = z.cfg.classes.get('RabbitMQAPI_VHost')
         actual = cls.containing_js_columns
-        self.assertEquals(EXPECTED, actual, 'component_grid_panel_js expected , got {}'.format(EXPECTED, actual))
+        self.assertEquals(EXPECTED, actual, 'containing_js_columns expected:\n{}\ngot:\n{}\n'.format(EXPECTED, actual))
 
 
 

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_inherited_relations.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_inherited_relations.py
@@ -27,7 +27,7 @@ from ZenPacks.zenoss.ZenPackLib import zenpacklib
 
 
 
-YAML_DOC="""
+YAML_DOC = """
 name: ZenPacks.zenoss.OpenStackInfrastructure
 zProperties:
   DEFAULTS:
@@ -45,7 +45,7 @@ classes:
     base: [zenpacklib.Component]
     relationships:
       endpoint:
-        grid_display: True
+        grid_display: true
         label: Endpoint
   OrgComponent:
     base: [OpenstackComponent]
@@ -66,9 +66,11 @@ classes:
     label: Availability Zone
     order: 2
     relationships:
+      parentOrg:
+        label: Parent
       childOrgs:
-        grid_display: False
-        details_display: False
+        grid_display: false
+        details_display: false
 """
 
 
@@ -80,9 +82,40 @@ class TestZen23763(BaseTestCase):
 
     def test_inherited_relation_display(self):
         CFG = zenpacklib.load_yaml(YAML_DOC)
+        comp = CFG.classes.get('OpenstackComponent')
+        org = CFG.classes.get('OrgComponent')
         az = CFG.classes.get('AvailabilityZone')
-        rel = az.relationships.get('parentOrg')
-        self.assertEquals(rel.label, 'Parent Region', 'Inherited relation display properties failed')
+
+        self.property_value(comp, 'endpoint', 'grid_display', True)
+        self.property_value(comp, 'endpoint', 'label', 'Endpoint')
+        self.property_value(org, 'endpoint', 'grid_display', True)
+        self.property_value(org, 'endpoint', 'label', 'Endpoint')
+        self.property_value(az, 'endpoint', 'grid_display', True)
+        self.property_value(az, 'endpoint', 'label', 'Endpoint')
+
+        self.property_value(org, 'parentOrg', 'grid_display', True)
+        self.property_value(org, 'parentOrg', 'label', 'Parent Region')
+        self.property_value(org, 'parentOrg', 'label_width', 60)
+
+        self.property_value(az, 'parentOrg', 'grid_display', True)
+        self.property_value(az, 'parentOrg', 'label', 'Parent')
+        self.property_value(az, 'parentOrg', 'label_width', 60)
+
+        self.property_value(org, 'childOrgs', 'grid_display', True)
+        self.property_value(org, 'childOrgs', 'label', 'Children')
+        self.property_value(org, 'childOrgs', 'label_width', 60)
+
+        self.property_value(az, 'childOrgs', 'grid_display', False)
+        self.property_value(az, 'childOrgs', 'label', 'Children')
+        self.property_value(az, 'childOrgs', 'label_width', 60)
+
+    def property_value(self, spec, rel_name, attr_name, expected):
+        rel = spec.relationships.get(rel_name)
+        actual = getattr(rel, attr_name, None)
+        self.assertEquals(expected, actual,
+                          '{} has unexpected value for "{}", expected: {}, actual: {}'.format(
+                          spec.name, rel_name, expected, actual)
+                          )
 
 def test_suite():
     """Return test suite for this module."""

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_threshold_graphpoint_legends.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_threshold_graphpoint_legends.py
@@ -63,7 +63,7 @@ device_classes:
 """
 
 EXPECTED = {'A': {'color': '', 'legend': '${graphPoint/id}'},
-            'a': {'color': 234234, 'legend': 'test_a'},
+            'a': {'color': '234234', 'legend': 'test_a'},
             'b': {'color': '', 'legend': 'test_b'},
             'c': {'color': 'AAAAAA', 'legend': '${graphPoint/id}'}}
 


### PR DESCRIPTION
* Add "Relationship" type to handle input validation and relationship
class, cardinality, and name
* Prevent duplicate class_relationships spec building in
ZenPackSpecParams
* Moved majority of ZenPackSpec init method relationship handling to
ClassSpec, ClassRelationshipSpec, RelationshipSpec
* create ClassRelationshipSpec 'plumb' method to handle imported classes
handling
* Added ClassSpec 'plumb_class_relations' method to handle invalid
relationship detection and call to relationship 'plumb' method
* Added 'get_custom_params' to Spec
* Ensure class relationships are handled in order for inheritance
overrides
* Avoid premature calls to spec.model_class
* Ensure inheritance of ClassSpec properties and property parameters
* Ensure proper behavior of DEFAULTS and local attribute overrides on
each ClassPropertySpec
* Added comprehensive unit test for class properties
* Added comprehensive test_inherited_relations unit test
* Fixed unit test failures
* Removed unused imports
* Misc pep8