### PR TITLE
Add in functions that were also available in single module

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
+++ b/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
@@ -62,8 +62,8 @@ from lib.base.Component import (
     WinService
     )
 
-
-from lib.functions import relationships_from_yuml
+from lib.spec import ZenPackSpec
+from lib.functions import relationships_from_yuml, catalog_search, ucfirst, relname_from_classname
 
 if __name__ == '__main__':
     from lib.libexec.ZPLCommand import ZPLCommand


### PR DESCRIPTION
OSI zp is trying to import catalog_search.  there could end up being more of these, but for now this is what was exported by wildcard