### PR TITLE
Support metric facade performance enhancements (ZEN-23870)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Features
 * Deprecated support for python-based "yaml" specifications
 * Support for threshold graphpoint legend and color (ZEN-24904)
 * Ability to specify an initial sort column on a component grid
+* Performance enhancments for grid display of metrics (ZEN-23870)
 
 Fixes
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -63,6 +63,8 @@ class RRDTemplateSpec(Spec):
 
         self.validate_references()
 
+        self.datapoints_to_fetch = self.get_dp_names()
+
     def validate_references(self):
         """
             validate 
@@ -83,6 +85,13 @@ class RRDTemplateSpec(Spec):
                                        'Graph Point',
                                        set([gp_spec.dpName]),
                                        ds_dp_names)
+
+    def get_dp_names(self):
+        """return list of datapoint names"""
+        dp_names = []
+        for ds_spec in self.datasources.values():
+            dp_names += [ id for id in ds_spec.datapoints.keys() ]
+        return list(set(dp_names))
 
     def get_ds_dp_names(self):
         """return set of dsname_dpname"""


### PR DESCRIPTION
* Fixes ZEN-23870
* Added "dataPointsToFetch" attribute to all generated Info classes
* ClassSpec datapoint_method uses "getFetchedDataPoint" instead of
"getRRDValue" when available
* Updated ClassSpec and RRDTemplateSpec to related associated datapoints
from "monitoring_templates"