### PR TITLE
Preserve order for graphs/datsources (ZEN-26115, ZEN-26116)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -226,10 +226,7 @@ class Spec(object):
                 self.apply_data_defaults(param_dict, leave_defaults=leave_defaults)
 
         specs = OrderedDict()
-        keys = param_dict.keys()
-        keys.sort()
-        for k in keys:
-            v = param_dict.get(k)
+        for k, v in param_dict.iteritems():
             args = fix_kwargs(v)
             args['zplog'] = zplog
             specs[k] = spec_type(self, k, **(args))

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_datapoint_shorthand.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_datapoint_shorthand.py
@@ -58,8 +58,8 @@ device_classes:
           datasource:
             type: SNMP
             datapoints:
-              dp_counter_map: COUNTER
               dp_gauge: GAUGE
+              dp_counter_map: COUNTER
               dp_gauge_map_alias:
                 rrdtype: GAUGE
                 aliases: {dp_gauge_map: null}


### PR DESCRIPTION
- Fixes ZEN-26115
- Fixes ZEN-26116
- Revert earlier intentional sorting of keys in specs_from_params
- Template design now follows YAML specification.
- Updated test_datapoint_shorthand unit test