### PR TITLE
Include zenpacklib TestCase for backwards compatibility

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ComponentBase.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ComponentBase.py
@@ -69,7 +69,7 @@ class ComponentBase(ModelBase):
         if name in property_dict:
             # and if we know how to handle it
             target_class = target_type_map.get(property_dict.get(name))
-            if target_class:
+            if target_class and value is not None:
                 try:
                     value = target_class(value)
                 except Exception as e:

--- a/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
+++ b/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
@@ -33,6 +33,7 @@ __version__ = "2.0.0dev"
 # BaseTestCase which puts Zope into testing mode.
 TestCase = None
 
+import logging
 import Globals
 from Products.ZenUtils.Utils import unused
 unused(Globals)
@@ -60,14 +61,108 @@ from lib.base.Component import (
     Service,
     IpService,
     WinService
-    )
+)
 
 from lib.spec import ZenPackSpec
 from lib.functions import relationships_from_yuml, catalog_search, ucfirst, relname_from_classname
 
+LOG = logging.getLogger('zen.ZenPackLib')
+
+
 def enableTesting():
-    """deprecated"""
-    pass
+    """This is for backwards compatibility.  For future tests, use ZPLTestHarness
+
+    Enable test mode. Only call from code under tests/.
+
+    If this is called from production code it will cause all Zope
+    clients to start in test mode. Which isn't useful for anything but
+    unit testing.
+
+    """
+    global TestCase
+
+    if TestCase:
+        return
+
+    from Products.ZenTestCase.BaseTestCase import BaseTestCase
+    from transaction._transaction import Transaction
+
+    class TestCase(BaseTestCase):
+
+        # As in BaseTestCase, the default behavior is to disable
+        # all logging from within a unit test.  To enable it,
+        # set disableLogging = False in your subclass.  This is
+        # recommended during active development, but is too noisy
+        # to leave as the default.
+        disableLogging = True
+
+        def afterSetUp(self):
+            super(TestCase, self).afterSetUp()
+
+            # Not included with BaseTestCase. Needed to test that UI
+            # components have been properly registered.
+            from Products.Five import zcml
+            import Products.ZenUI3
+            zcml.load_config('configure.zcml', Products.ZenUI3)
+
+            if not hasattr(self, 'zenpack_module_name') or self.zenpack_module_name is None:
+                self.zenpack_module_name = '.'.join(self.__module__.split('.')[:-2])
+
+            try:
+                import importlib
+                zenpack_module = importlib.import_module(self.zenpack_module_name)
+            except Exception:
+                LOG.exception("Unable to load zenpack named '%s' - is it installed? (%s)", self.zenpack_module_name)
+                raise
+
+            zenpackspec = getattr(zenpack_module, 'CFG', None)
+            if not zenpackspec:
+                raise NameError(
+                    "name {!r} is not defined"
+                    .format('.'.join((self.zenpack_module_name, 'CFG'))))
+
+            zenpackspec.test_setup()
+
+            import Products.ZenEvents
+            zcml.load_config('meta.zcml', Products.ZenEvents)
+
+            try:
+                import ZenPacks.zenoss.DynamicView
+                zcml.load_config('configure.zcml', ZenPacks.zenoss.DynamicView)
+            except ImportError:
+                pass
+
+            try:
+                import ZenPacks.zenoss.Impact
+                zcml.load_config('meta.zcml', ZenPacks.zenoss.Impact)
+                zcml.load_config('configure.zcml', ZenPacks.zenoss.Impact)
+            except ImportError:
+                pass
+
+            try:
+                zcml.load_config('configure.zcml', zenpack_module)
+            except IOError:
+                pass
+
+            # BaseTestCast.afterSetUp already hides transaction.commit. So we also
+            # need to hide transaction.abort.
+            self._transaction_abort = Transaction.abort
+            Transaction.abort = lambda *x: None
+
+        def beforeTearDown(self):
+            super(TestCase, self).beforeTearDown()
+
+            if hasattr(self, '_transaction_abort'):
+                Transaction.abort = self._transaction_abort
+
+        # If the exception occurs during setUp, beforeTearDown is not called,
+        # so we also need to restore abort here as well:
+        def _close(self):
+            if hasattr(self, '_transaction_abort'):
+                Transaction.abort = self._transaction_abort
+
+            super(TestCase, self)._close()
+
 
 if __name__ == '__main__':
     from lib.libexec.ZPLCommand import ZPLCommand

--- a/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
+++ b/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
@@ -70,9 +70,7 @@ LOG = logging.getLogger('zen.ZenPackLib')
 
 
 def enableTesting():
-    """This is for backwards compatibility.  For future tests, use ZPLTestHarness
-
-    Enable test mode. Only call from code under tests/.
+    """Enable test mode. Only call from code under tests/.
 
     If this is called from production code it will cause all Zope
     clients to start in test mode. Which isn't useful for anything but


### PR DESCRIPTION
Fixes ZEN-26183

Redefine enableTesting.  This will only be called from a unit test
in another zenpack so it shouldn't cause zope clients to be in
test mode.

No need to try and instantiate a None.  could result in bad results