### PR TITLE
Reduce verbosity of datapoint consistency warnings (ZEN-26203)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -106,10 +106,10 @@ class RRDTemplateSpec(Spec):
         valid_names = dp_names.intersection(ref_names)
         invalid_names = dp_names.difference(ref_names)
         if len(valid_names) == 0:
-            self.LOG.error('{} {} has no valid datapoints'.format(spec_type,
+            self.LOG.warn('{} {} has no valid datapoints'.format(spec_type,
                                                                   spec_name))
         if len(invalid_names) > 0:
-            self.LOG.error('{} {} has invalid datapoints: {}'.format(spec_type,
+            self.LOG.warn('{} {} has invalid datapoints: {}'.format(spec_type,
                                                             spec_name,
                                                             ', '.join(list(invalid_names))))
 

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_datasource_datapoint_consistency.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_datasource_datapoint_consistency.py
@@ -111,16 +111,16 @@ class TestZen19461(BaseTestCase):
         self.assertEquals(actual, '', 'Datapoint validation failed:\n  {}'.format(actual))
 
     def test_invalid_yaml(self):
-        expected = '[ERROR] Threshold CPU Utilization has invalid datapoints: badReference_badReference\n' \
-            '[ERROR] Graph Point badGraphPoint has no valid datapoints\n'\
-            '[ERROR] Graph Point badGraphPoint has invalid datapoints: badReference_badReference\n'
+        expected = '[WARNING] Threshold CPU Utilization has invalid datapoints: badReference_badReference\n' \
+            '[WARNING] Graph Point badGraphPoint has no valid datapoints\n'\
+            '[WARNING] Graph Point badGraphPoint has invalid datapoints: badReference_badReference\n'
         actual = self.capture.test_yaml(INVALID_POINTS)
         self.assertEquals(actual, expected, 'Datapoint validation failed:\n  {}'.format(actual))
 
     def test_no_valid_yaml(self):
-        expected = '[ERROR] Threshold CPU Utilization has no valid datapoints\n'\
-        '[ERROR] Graph Point ssCpuRawIdle has no valid datapoints\n'\
-        '[ERROR] Graph Point ssCpuRawIdle has invalid datapoints: null_null\n'
+        expected = '[WARNING] Threshold CPU Utilization has no valid datapoints\n'\
+        '[WARNING] Graph Point ssCpuRawIdle has no valid datapoints\n'\
+        '[WARNING] Graph Point ssCpuRawIdle has invalid datapoints: null_null\n'
         actual = self.capture.test_yaml(NO_VALID_POINTS)
         self.assertEquals(actual, expected, 'Datapoint validation failed:\n  {}'.format(actual))
 


### PR DESCRIPTION
- Fixes ZEN-26203
- changed "error" to "warning" level for datapoint warning messages
- updated test_datasource_datapoint_consistency.py to accommodate