### PR TITLE
Avoid overwriting modeler plugins in existing device class (ZEN-24901)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,7 @@ Features
 * Support for threshold graphpoint legend and color (ZEN-24904)
 * Ability to specify an initial sort column on a component grid
 * Performance enhancments for grid display of metrics (ZEN-23870)
+* Existing device class modeler plugins appended by default (ZEN-24901) 
 
 Fixes
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
@@ -23,6 +23,7 @@ class DeviceClassSpec(Spec):
             templates=None,
             description=None,
             protocol=None,
+            overwrite_plugins=False,
             _source_location=None,
             zplog=None):
         """
@@ -40,6 +41,8 @@ class DeviceClassSpec(Spec):
             :type description: str
             :param protocol: Protocol to use for registered devtype
             :type protocol: str
+            :param overwrite_plugins: Whether to overwrite or append any given modeler plugins 
+            :type overwrite_plugins: bool
         """
         super(DeviceClassSpec, self).__init__(_source_location=_source_location)
         if zplog:
@@ -50,6 +53,7 @@ class DeviceClassSpec(Spec):
         self.remove = bool(remove)
         self.description = description
         self.protocol = protocol
+        self.overwrite_plugins = overwrite_plugins
 
         if zProperties is None:
             self.zProperties = {}

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_plugins.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_plugins.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    Test that modeler plugins are appended or replaced (ZEN-24901) 
+"""
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+
+# stdlib Imports
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+# zenpacklib Imports
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
+from ZenPacks.zenoss.ZenPackLib.lib.base.ZenPack import ZenPack
+
+
+YAML_DOC = """
+name: ZenPacks.zenoss.ZenPackLib
+
+device_classes:
+  /Server/ZenPackLib:
+    zProperties:
+      zCollectorPlugins:
+        - zenoss.snmp.DeviceMap
+        - snmp.bigip.DeviceMap
+"""
+
+
+class TestCollectorPlugins(BaseTestCase):
+    """
+    Test that modeler plugins are appended or replaced
+    """
+
+    def test_device_class_plugins(self):
+        path = '/Server/ZenPackLib'
+        dummy_plugin = 'dummy.plugin'
+        z = ZPLTestHarness(YAML_DOC)
+        z.connect()
+
+        # instantiate the ZenPack class
+        zenpack = ZenPack(z.dmd)
+
+        # create device class
+        dcObject = z.dmd.Devices.createOrganizer(path)
+        # add our preexisting plugin
+        dcObject.setZenProperty('zCollectorPlugins', [dummy_plugin])
+
+        self.assertTrue(len(dcObject.zCollectorPlugins) == 1, 'device class not created properly')
+
+        # create/update existing like install would
+        dcspec = z.cfg.device_classes.get(path)
+        dc = zenpack.create_device_class(z, dcspec)
+
+        # verify that dummy plugin still exists
+        self.assertTrue(dummy_plugin in dc.zCollectorPlugins, 'zCollectorPlugins not updated properly after update')
+        # verify that count is now 3
+        self.assertTrue(len(dc.zCollectorPlugins) == 3, 'zCollectorPlugins not updated properly after update')
+
+        # test "removal"
+        zenpack.remove_device_class(z, dcspec)
+
+        # verify that dummy plugin still exists
+        self.assertTrue(dummy_plugin in dcObject.zCollectorPlugins, 'zCollectorPlugins not updated properly after removal')
+        # verify that count is now 3
+        self.assertTrue(len(dcObject.zCollectorPlugins) == 1, 'zCollectorPlugins not updated properly after removal')
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestCollectorPlugins))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/docs/yaml-device-classes.rst
+++ b/docs/yaml-device-classes.rst
@@ -162,3 +162,10 @@ protocol
   :Required: No
   :Type: string
   :Default Value: None
+
+overwrite_plugins
+  :Description: Should a preexisting device class have its modeler plugins overwritten?
+  :Required: No
+  :Type: boolean
+  :Default Value: false
+


### PR DESCRIPTION
- Fixes ZEN-24901
- Append rather than overwrite modeler plugins if device class already
exists
- Ensure old plugins remain when ZP removed
- Added "overwrite_plugins" to DeviceClassSpec to force overwrite
- Updated CHANGES and docs
- Added test_device_class_plugins unit test