### PR TITLE
Add support for specifying a device link provider

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,7 @@ Features
 * Support for threshold graphpoint legend and color (ZEN-24904)
 * Ability to specify an initial sort column on a component grid
 * Performance enhancments for grid display of metrics (ZEN-23870)
+* Support for Device Link Providers
 
 Fixes
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -269,6 +269,7 @@ from ..params.GraphPointSpecParams import GraphPointSpecParams
 from ..params.ProcessClassSpecParams import ProcessClassSpecParams
 from ..params.ProcessClassOrganizerSpecParams import ProcessClassOrganizerSpecParams
 from ..params.ImpactTriggerSpecParams import ImpactTriggerSpecParams
+from ..params.LinkProviderSpecParams import LinkProviderSpecParams
 
 # Spec subclasses
 Dumper.add_representer(ZenPackSpec, Dumper.represent_zenpackspec)
@@ -303,6 +304,7 @@ Dumper.add_representer(EventClassMappingSpec, Dumper.represent_spec)
 Dumper.add_representer(ProcessClassOrganizerSpecParams, Dumper.represent_spec)
 Dumper.add_representer(ProcessClassSpecParams, Dumper.represent_spec)
 Dumper.add_representer(ImpactTriggerSpecParams, Dumper.represent_spec)
+Dumper.add_representer(LinkProviderSpecParams, Dumper.represent_spec)
 # representers for custom types
 from ..base.types import Color, Severity
 Dumper.add_representer(Color, SafeRepresenter.represent_str)

--- a/ZenPacks/zenoss/ZenPackLib/lib/links.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/links.py
@@ -1,0 +1,70 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+from .functions import catalog_search
+
+log = logging.getLogger('zen.ZenPackLib')
+
+
+class DeviceLinkProvider(object):
+    """
+    Provides links
+    """
+    queries = ''
+
+    def __init__(self, device):
+        self.device = device
+
+    def getExpandedLinks(self):
+        links = []
+        # Find types that match and return them
+        try:
+            link_providers = self.device.link_providers
+        except Exception:
+            log.warn('No link providers defined for device {} in {}'.format(self.device.id,
+                                                                            self.device.zenpack_name))
+            return links
+
+        for lp_key, link_provider in link_providers.iteritems():
+            class_name = '.'.join([self.device.zPythonClass, self.device.__class__.__name__])
+            queries = {}
+            for key, value in link_provider.queries.iteritems():
+                try:
+                    # look for attribute of device
+                    queries[key] = getattr(self.device, value)
+                except AttributeError:
+                    # could be a specific value, such as a meta_type
+                    queries[key] = value
+
+            # make sure we're looking at the right class and there is at least one query
+            if link_provider.link_class == class_name and queries:
+                # get the scope, either local to device, global, or local to device class
+                if link_provider.global_search:
+                    scope = self.device.getDmdRoot('Devices')
+                else:
+                    try:
+                        scope = self.device.getDmdRoot('Devices').getOrganizer(link_provider.device_class)
+                    except (KeyError, TypeError, AttributeError):
+                        scope = self.device.device()
+
+                # use named catalog
+                results = catalog_search(scope, link_provider.catalog, **queries)
+
+                for brain in results:
+                    obj = brain.getObject()
+                    links.append(
+                        '{}: <a href="{}">{}</a>'.format(
+                            link_provider.link_title,
+                            obj.getPrimaryUrlPath(),
+                            obj.titleOrId()
+                        )
+                    )
+
+        return links

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/LinkProviderSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/LinkProviderSpecParams.py
@@ -1,0 +1,29 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+from .SpecParams import SpecParams
+from ..spec.LinkProviderSpec import LinkProviderSpec
+
+
+class LinkProviderSpecParams(SpecParams, LinkProviderSpec):
+    def __init__(self,
+                 zenpack_spec,
+                 link_title,
+                 global_search=False,
+                 link_class='Products.ZenModel.Device.Device',
+                 device_class=None,
+                 catalog='device',
+                 queries=None,
+                 **kwargs):
+        SpecParams.__init__(self, **kwargs)
+        self.link_title = link_title
+        self.global_search = global_search
+        self.link_class = link_class
+        self.device_class = device_class
+        self.catalog = catalog
+        self.queries = queries

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -19,6 +19,7 @@ from Products.Zuul.form import schema
 from Products.Zuul.form.interfaces import IFormBuilder
 from Products.Zuul.infos import InfoBase, ProxyProperty
 from Products.Zuul.interfaces import IInfo
+from Products.ZenModel.interfaces import IExpandedLinkProvider
 
 from ..wrapper.ComponentFormBuilder import ComponentFormBuilder
 from ..utils import impact_installed, dynamicview_installed, has_metricfacade, FACET_BLACKLIST
@@ -31,6 +32,12 @@ from ..base.Component import Component, HWComponent, Service
 from ..base.Device import Device
 from ..zuul import schema_map
 
+from .Spec import Spec, DeviceInfoStatusProperty, \
+    RelationshipInfoProperty, RelationshipGetter, RelationshipSetter
+from .ClassPropertySpec import ClassPropertySpec
+from .ClassRelationshipSpec import ClassRelationshipSpec
+from .ImpactTriggerSpec import ImpactTriggerSpec
+
 DYNAMICVIEW_INSTALLED = dynamicview_installed()
 if DYNAMICVIEW_INSTALLED:
     from ZenPacks.zenoss.DynamicView.interfaces import IRelatable, IRelationsProvider
@@ -42,12 +49,6 @@ if IMPACT_INSTALLED:
     from ZenPacks.zenoss.Impact.impactd.interfaces import IRelationshipDataProvider, INodeTriggers
     from ..impact import ImpactRelationshipDataProvider
     from ..base.BaseTriggers import BaseTriggers
-
-from .Spec import Spec, DeviceInfoStatusProperty, \
-    RelationshipInfoProperty, RelationshipGetter, RelationshipSetter
-from .ClassPropertySpec import ClassPropertySpec
-from .ClassRelationshipSpec import ClassRelationshipSpec
-from .ImpactTriggerSpec import ImpactTriggerSpec
 
 HAS_METRICFACADE = has_metricfacade()
 
@@ -262,7 +263,6 @@ class ClassSpec(Spec):
         self.properties = self.specs_from_param(
             ClassPropertySpec, 'properties', properties, zplog=self.LOG)
 
-
         # Relationships
         # If these exist, they will refer to relationship display properties, but won't have a schema
         # defined (yet).  The schema is added later
@@ -387,7 +387,7 @@ class ClassSpec(Spec):
 
     def plumb_class_relations(self):
         """
-            Plumb class relations and update 
+            Plumb class relations and update
             remote class _v_local_relations/_relations
             as well as updating NEW_RELATIONS and NEW_COMPONENT_TYPES
         """
@@ -397,7 +397,7 @@ class ClassSpec(Spec):
                 # this happens if the ClassSpec sets display properties for a nonexistent relation
                 if not relationship.schema:
                     self.LOG.error("Removing invalid display config for relationship {} from  {}.{}".format(
-                                relname, self.zenpack.name, self.name))
+                        relname, self.zenpack.name, self.name))
                     self.relationships.pop(relname)
                     continue
                 relationship.plumb()
@@ -409,7 +409,7 @@ class ClassSpec(Spec):
             rel_spec.update_inherited_params()
 
     def update_child_relations(self, relname):
-        """ Update relationships with any that 
+        """ Update relationships with any that
             should be inherited from base classes
         """
         # process descendants first
@@ -656,8 +656,8 @@ class ClassSpec(Spec):
                 'weight': self.dynamicview_weight,
                 'type': self.zenpack.name,
                 'icon': self.icon_url,
-                },
-            }
+            },
+        }
 
         properties = []
         relations = []
@@ -754,6 +754,9 @@ class ClassSpec(Spec):
         attributes['impact_triggers'] = [t.get_trigger() for t in self.impact_triggers.values()]
 
         attributes['dynamicview_relations'] = self.dynamicview_relations
+
+        # Add link provider
+        attributes['link_providers'] = self.zenpack.link_providers
 
         # And facet patterns.
         if self.path_pattern_streams:

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/LinkProviderSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/LinkProviderSpec.py
@@ -1,0 +1,85 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+from .Spec import Spec
+
+'''
+Example
+
+link_providers:
+    Cluster Node:
+        global_search: False
+        link_class: ZenPacks.zenoss.Microsoft.Windows.Device.Device
+        catalog: device
+        queries:
+            - id:clusterhostdevices
+    Cluster:
+        link_class: ZenPacks.zenoss.Microsoft.Windows.Device.Device
+        queries:
+            - id:clusterdevices
+        device_class: /Server/Microsoft/Cluster
+'''
+
+
+class LinkProviderSpec(Spec):
+    """Initialize a LinkProviderClass via Python at install time."""
+
+    def __init__(
+            self,
+            class_spec,
+            link_title,
+            global_search=False,
+            link_class='ZenPacks.zenoss.ZenPackLib.lib.base.Device.Device',
+            device_class=None,
+            catalog='device',
+            queries=None,
+            _source_location=None,
+            zplog=None):
+        """
+            Create a Device Link Provider Specification
+
+            :param global_search: Search global catalog?
+            :type global_search: bool
+            :param link_class: Class for which this is a provider
+            :type link_class: str
+            :param device_class: Device class which contains the search catalog
+            :type device_class: str
+            :param catalog: name of catalog to search.  device, component, etc.
+            :type catalog: str
+            :param queries: Queries to match on search results in remote:local format.
+                    e.g. id:manageIp denotes a match on the remote id with the device's manageIp
+            :type queries: list(str)
+        """
+        super(LinkProviderSpec, self).__init__(_source_location=_source_location)
+        if zplog:
+            self.LOG = zplog
+        self.link_title = link_title
+        self.global_search = global_search
+        self.link_class = link_class
+        self.catalog = catalog
+        self.queries = queries
+        self.device_class = device_class
+
+    @property
+    def queries(self):
+        return self._queries
+
+    @queries.setter
+    def queries(self, value):
+        self._queries = {}
+        if not value:
+            self.LOG.error('Link provider queries for {} cannot be empty.'.format(self.link_title))
+        if not isinstance(value, list):
+            self.LOG.warn('Link provider queries must be a list of strings: {}'.format(value))
+            return
+        for query in value:
+            try:
+                left, right = query.split(':', 1)
+                self._queries[left] = right
+            except ValueError:
+                self.LOG.warn('Link provider query must be matched pairs.  Discarding "{}"'.format(query))

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_link_providers.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_link_providers.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    Test link providers
+"""
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
+
+unused(Globals)
+
+
+LINK_PROVIDER_YAML = """
+name: ZenPacks.zenoss.ZenPackLib
+link_providers:
+    Cluster Node:
+        global_search: false
+        link_class: ZenPacks.zenoss.Microsoft.Windows.Device.Device
+        catalog: device
+        queries:
+            - id:clusterhostdevices
+    Cluster:
+        link_class: ZenPacks.zenoss.Microsoft.Windows.Device.Device
+        queries:
+            - id:clusterdevices
+        device_class: /Server/Microsoft/Cluster
+"""
+
+EXPECTED_YAML = {
+    'link_providers': {
+        'Cluster': {
+            'device_class': '/Server/Microsoft/Cluster',
+            'link_class': 'ZenPacks.zenoss.Microsoft.Windows.Device.Device',
+            'queries': ['id:clusterdevices']
+        },
+        'Cluster Node': {
+            'global_search': False,
+            'catalog': 'device',
+            'link_class': 'ZenPacks.zenoss.Microsoft.Windows.Device.Device',
+            'queries': ['id:clusterhostdevices']
+        }
+    },
+    'name': 'ZenPacks.zenoss.ZenPackLib'
+}
+
+link_provider_zp = ZPLTestHarness(LINK_PROVIDER_YAML)
+
+
+class TestLinkProviders(BaseTestCase):
+    """Test Event Classes
+    """
+
+    def test_link_providers(self):
+        self.maxDiff = None
+        self.assertEquals(len(link_provider_zp.yaml['link_providers']), len(link_provider_zp.cfg.link_providers))
+        self.assertEquals(EXPECTED_YAML, link_provider_zp.yaml)
+        link_providers = link_provider_zp.cfg.link_providers
+        self.assertFalse(link_providers['Cluster'].global_search)
+        self.assertEquals(link_providers['Cluster'].link_class, 'ZenPacks.zenoss.Microsoft.Windows.Device.Device')
+        self.assertEquals(link_providers['Cluster'].catalog, 'device')
+        self.assertEquals(link_providers['Cluster'].queries, {'id': 'clusterdevices'})
+        self.assertIsNone(link_providers['Cluster Node'].device_class)
+        self.assertEquals(link_providers['Cluster Node'].catalog, 'device')
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestLinkProviders))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/docs/yaml-link-providers.rst
+++ b/docs/yaml-link-providers.rst
@@ -1,0 +1,68 @@
+.. _device-link-providers:
+
+#####################
+Device Link Providers
+#####################
+
+A device link provider is a subscriber interface that gives a hook for adding context-specific html links (for example, the device links on the Device Details page).  Zenpacklib provides a simple class to search the global catalog, device class catalog, or a device local catalog that match a specific query.
+
+.. code-block:: yaml
+
+      name: ZenPacks.zenoss.BasicZenPack
+
+      link_providers:
+        Virtual Machine:
+          link_class: ZenPacks.example.XenServer
+          catalog: device
+          device_class: /Server/XenServer
+          queries: [vm_id:manageIp]
+        XenServer:
+          global_search: True
+          queries: [manageIp:vm_id]
+
+
+To search the global catalog, set *global_search* to true.  If the catalog you wish to search is in a specific device class, set *global_search* to false and specify the class name with *device_class*.  To search a catalog on the local device, simply set *global_search* to false and do not set *device_class*.  You can use one or more queries to match up devices/components.  In the above example, the XenServer provider will search the global device catalog and match any device's *manageIp* attribute with the current device's *vm_id* attribute.
+
+.. _device-link-provider-fields:
+
+***************************
+Device Link Provider Fields
+***************************
+
+The following fields are valid for a device link provider entry.
+
+link_title:
+  :Description: Title which will appear on the overview page of the type of device or component.
+  :Required: Yes
+  :Type: string
+  :Default Value: *(implied from key in relationships map)*
+
+global_search:
+  :Description: Search the global catalog?
+  :Required: No
+  :Type: boolean
+  :Default Value: false
+
+link_class:
+  :Description: Python class on which this provider will apply.  You must supply the full python class name.  For example, 'ZenPacks.example.XenServer.Device.Device'.
+  :Required: No
+  :Type: string
+  :Default Value: 'Products.ZenModel.Device.Device'
+
+device_class:
+  :Description: Device class containing the catalog which to search.  You must supply the full device class name.  For example, '/Server/XenServer'.
+  :Required: No
+  :Type: string
+  :Default Value: None
+
+catalog:
+  :Description: Catalog name on which to search for linked devices/components
+  :Required: No
+  :Type: string
+  :Default Value: 'device'
+
+queries:
+  :Description: Queries to use to match a linked device/component.  Each query must be in *remote:local* format, meaning that the catalog search will match a remote attribute with a local attribute.  The local search term could also be actual text.  Examples: *id:manageIp* will match the remote id attribute with the local device's manageIp attribute, and *meta_type:ClusterDevice* will match the meta_type on a remote device to "ClusterDevice".
+  :Required: Yes
+  :Type: list<string>
+  :Default Value: None

--- a/docs/yaml-reference.rst
+++ b/docs/yaml-reference.rst
@@ -15,6 +15,7 @@ following sections describe the syntax and capabilities of this YAML file.
     yaml-device-classes
     yaml-monitoring-templates
     yaml-classes-and-relationships
+    yaml-link-providers
     yaml-event-classes
     yaml-process-classes
 


### PR DESCRIPTION
Fixes ZEN-26005

Link provider takes title, device class, search types, and attributes
to match up to find links.

Allows for multiple link providers to be defined

Allows user to specify global or local search, name of catalog,
multiple queries.  This can also be used to set up the reverse
links.

Adds ability to specify device class to search for a named catalog.

Updated docs also

Allows to search for specific text