### PR TITLE
Avoid setting zProperties on existing device classes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,19 @@
 Version 2.0
 ===========
 
+Backwards Incompatible Changes
+
+* Any installed ZenPacks using older versions of zenpacklib.py will continue to function unchanged.
+* Using version 2.0 is slightly different.  The __init__.py file import statements should now contain the following:
+
+.. code-block:: python
+
+    from ZenPacks.zenoss.ZenPackLib import zenpacklib
+    CFG = zenpacklib.load_yaml()
+    schema = CFG.zenpack_module.schema
+
+* zProperties will not be updated automatically on existing device classes.  These should be handled on a case basis by using migrate scripts.
+
 Release 2.0.0
 -------------
 
@@ -29,6 +42,7 @@ Features
 * Performance enhancments for grid display of metrics (ZEN-23870)
 * Support for Device Link Providers
 * Added troubleshooting aid for easily saving function data(writeDataToFile)
+* Avoid setting zProperties on existing device class (ZPS-137)
 
 Fixes
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -290,13 +290,20 @@ class ZenPack(ZenPackBase):
 
     def create_device_class(self, app, dcspec):
         ''''''
+        exists = False
         try:
             dcObject = app.dmd.Devices.getOrganizer(dcspec.path)
+            exists = True
         except KeyError:
             self.LOG.info('Creating DeviceClass {}'.format(dcspec.path))
             dcObject = app.dmd.Devices.createOrganizer(dcspec.path)
 
         for zprop, value in dcspec.zProperties.iteritems():
+            # Avoid setting zProperties on an existing device class
+            if exists:
+                if value != getattr(dcObject, zprop):
+                    self.LOG.debug('Not setting "{}" to "{}" on existing device class ({})'.format(zprop, value, dcspec.path))
+                continue
             if dcObject.getPropertyType(zprop) is None:
                 self.LOG.error("Unable to set zProperty {} on {} (undefined zProperty)".format(zprop, dcspec.path))
             else:

--- a/docs/yaml-device-classes.rst
+++ b/docs/yaml-device-classes.rst
@@ -61,6 +61,14 @@ set each time the ZenPack is installed.
          zWidgeterEnable: true
          zWidgeterInterval: 60
 
+
+.. note::
+
+   As of version 2.0, zProperties will not be set on existing device classes during
+   ZenPack installation.  Developers wishing to do so should handle these cases via 
+   migrate scripts that run during the installation process.
+
+
 The referenced zProperties must already exist in the Zenoss system, or be
 added by your ZenPack via a global :ref:`zProperties` entry.
 


### PR DESCRIPTION
- Addresses (ZPS-137)
- zProperties will no longer be set on preexisting device classes
- Updated CHANGES and yaml-device-classes.rst regarding these changes