### PR TITLE
Take !ZenPackSpec tag into account

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -79,6 +79,7 @@ Fixes
 * Ensure device classes can be removed properly (ZEN-18134)
 * Ensure that datapoint alias keys do not exceed 31 chars (ZEN-17950)
 * Log obscure error with ill-defined relationships (ZEN-16701)
+* Fix handling of !ZenPackSpec tag in yaml definitions
 
 
 Version 1.1

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
@@ -150,6 +150,9 @@ class Loader(yaml.Loader):
                 self.LOG.error("No key found for {} in {}".format(yaml_key, param_name_map))
 
             # default construction
+            if value_node.tag == '!ZenPackSpec' and isinstance(value_node, yaml.MappingNode):
+                self.LOG.debug("Obsolete tag '!ZenPackSpec' found, changing to 'tag:yaml.org,2002:map'.")
+                value_node.tag = u'tag:yaml.org,2002:map'
             yaml_value = self.construct_object(value_node)
 
             # expected type should fall back to string if not given

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -83,6 +83,9 @@ or added if it does not exist.
    Import statements should also be checked throughout any class overrides or 
    other python files, since the statements will fail if they refer to the older zenpacklib.py.
 
+.. note::
+
+   The tag *!ZenPackSpec* is not necessary and should be removed from your yaml definitions.
 
 .. _new-logging:
 


### PR DESCRIPTION
Fixes ZPS-319

!ZenPackSpec indicates the loader needs to construct a zenpack from
the current node.  Changing to mapping node to load yaml correctly