### PR TITLE
Streamline and better document "order" parameter (ZPS-124)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
@@ -31,7 +31,7 @@ class ClassPropertySpec(Spec):
             details_display=True,
             grid_display=True,
             renderer=None,
-            order=None,
+            order=100,
             editable=False,
             api_only=False,
             api_backendtype='property',
@@ -79,8 +79,8 @@ class ClassPropertySpec(Spec):
                    to this property, rather than passing the text through
                    unformatted.
             :type renderer: str
-            :param order: TODO
-            :type order: float
+            :param order: Rank for sorting this property among other properties
+            :type order: int
             :param editable: TODO
             :type editable: bool
             :param api_only: TODO
@@ -150,11 +150,11 @@ class ClassPropertySpec(Spec):
                 "Property '%s': index_scope must be 'device', 'global', or 'both', not '%s'"
                 % (name, self.index_scope))
 
-        # Force properties into the 4.0 - 4.9 order range.
-        if not order:
-            self.order = 4.5
-        else:
-            self.order = 4 + (max(0, min(100, order)) / 100.0)
+        self.order = order
+
+    @property
+    def scaled_order(self):
+        return self.scale_order(scale=1, offset=4)
 
     def update_inherited_params(self):
         """Copy any inherited parameters if they are not default or already specified here"""
@@ -216,7 +216,7 @@ class ClassPropertySpec(Spec):
             self.name: schema_map[self.type_](
                 title=_t(self.label),
                 alwaysEditable=self.editable,
-                order=self.order)
+                order=self.scaled_order)
             }
 
     @property

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassRelationshipSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassRelationshipSpec.py
@@ -32,7 +32,7 @@ class ClassRelationshipSpec(Spec):
             grid_display=True,
             renderer=None,
             render_with_type=False,
-            order=None,
+            order=100,
             _source_location=None,
             zplog=None
             ):
@@ -73,8 +73,8 @@ class ClassRelationshipSpec(Spec):
                    may have several subclasses, such that the base class +
                    target object is not sufficiently descriptive on its own.
             :type render_with_type: bool
-            :param order: TODO
-            :type order: float
+            :param order: Rank for sorting this relationship among other relationships
+            :type order: int
 
         """
         super(ClassRelationshipSpec, self).__init__(_source_location=_source_location)
@@ -93,6 +93,7 @@ class ClassRelationshipSpec(Spec):
         self.grid_display = grid_display
         self.renderer = renderer
         self.render_with_type = render_with_type
+
         self.order = order
 
         if not self.display:
@@ -158,6 +159,13 @@ class ClassRelationshipSpec(Spec):
         return spec
 
     @property
+    def scaled_order(self):
+        if isinstance(self.schema, (ToOne)):
+            return self.scale_order(scale=1, offset=3)
+        else:
+            return self.scale_order(scale=1, offset=6)
+
+    @property
     def iinfo_schemas(self):
         """Return IInfo attribute schema dict."""
         remote_spec = self.class_.zenpack.classes.get(self.remote_classname)
@@ -179,13 +187,13 @@ class ClassRelationshipSpec(Spec):
                 schemas[self.name] = schema.Entity(
                     title=_t(self.label or remote_spec.label),
                     group="Overview",
-                    order=self.order or 3.0)
+                    order=self.scaled_order)
         else:
             relname_count = '{}_count'.format(self.name)
             schemas[relname_count] = schema.Int(
                 title=_t(u'Number of {}'.format(self.label or remote_spec.plural_label)),
                 group="Overview",
-                order=self.order or 6.0)
+                order=self.scaled_order)
 
         return schemas
 
@@ -287,7 +295,7 @@ class ClassRelationshipSpec(Spec):
 
         return [
             OrderAndValue(
-                order=self.order or remote_spec.order,
+                order=self.scaled_order or remote_spec.scaled_order,
                 value='{{{}}}'.format(',\n                       '.join(column_fields))),
             ]
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
@@ -146,6 +146,8 @@ class ZenPackSpec(Spec):
 
         # Classes
         self.classes = self.specs_from_param(ClassSpec, 'classes', classes, zplog=self.LOG)
+        # deal with float order parameters if they exist
+        self.normalize_child_order(self.classes.values())
 
         # update properties from ancestor classes
         self.plumb_properties()
@@ -289,7 +291,7 @@ class ZenPackSpec(Spec):
             if x.is_device}
 
         order = {
-            x.meta_type: float(x.order)
+            x.meta_type: x.scaled_order
             for x in self.classes.itervalues()}
 
         def getComponentTree(self, uid=None, id=None, **kwargs):

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_order_handlers.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_order_handlers.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    Validate handling, normalization, and scaling of order parameter across Specs
+"""
+# Zenoss Imports
+import Globals  # noqa
+from Products.ZenUtils.Utils import unused
+unused(Globals)
+
+# stdlib Imports
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+# zenpacklib Imports
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
+
+YAML_DOC = '''name: ZenPacks.zenoss.ZenPackLib
+class_relationships:
+- BasicDevice 1:MC BasicComponent
+- SubComponent M:M AuxComponent
+
+classes:
+  BasicDevice:
+    base: [zenpacklib.Device]
+    properties:
+        a: {}
+        b: {}
+        c: {}
+  BasicComponent:
+    base: [zenpacklib.Component]
+    properties:
+        a: {}
+        b: {}
+  SubComponent:
+    base: [BasicComponent]
+    relationships:
+        auxComponents: {}
+        basicDevice: {}
+  AuxComponent:
+    base: [SubComponent]
+    properties:
+        a: {}
+        b: {}
+'''
+
+YAML_DOC_INT = '''name: ZenPacks.zenoss.ZenPackLib
+class_relationships:
+- BasicDevice 1:MC BasicComponent
+- SubComponent M:M AuxComponent
+
+classes:
+  BasicDevice:
+    base: [zenpacklib.Device]
+    properties:
+        a:
+            order: 1
+        b:
+            order: 2
+        c:
+            order: 3
+  BasicComponent:
+    base: [zenpacklib.Component]
+    order: 1
+    properties:
+        a:
+            order: 1
+        b:
+            order: 2
+  SubComponent:
+    base: [BasicComponent]
+    order: 2
+    relationships:
+        auxComponents:
+            order: 1
+        basicDevice:
+            order: 2
+  AuxComponent:
+    base: [SubComponent]
+    order: 3
+    properties:
+        a:
+            order: 2
+        b:
+            order: 1
+'''
+
+YAML_DOC_FLOAT = '''name: ZenPacks.zenoss.ZenPackLib
+class_relationships:
+- BasicDevice 1:MC BasicComponent
+- SubComponent M:M AuxComponent
+
+classes:
+  BasicDevice:
+    base: [zenpacklib.Device]
+    properties:
+        a:
+            order: 1.5
+        b:
+            order: 1.6
+        c:
+            order: 1.7
+  BasicComponent:
+    base: [zenpacklib.Component]
+    order: 1.1
+    properties:
+        a:
+            order: 1.3
+        b:
+            order: 1.0
+  SubComponent:
+    base: [BasicComponent]
+    order: 1.2
+    relationships:
+        auxComponents:
+            order: 50.5
+        basicDevice:
+            order: 3.3
+  AuxComponent:
+    base: [SubComponent]
+    order: 1.3
+    properties:
+        a:
+            order: 1.2
+        b:
+            order: 1.1
+'''
+
+EXPECTED_INT = {'AuxComponent': {'relationships': {'basicDevice': {'scaled': 3.02, 'order': 2}, 'auxComponents': {'scaled': 6.01, 'order': 1}, 'subComponents': {'scaled': 7.0, 'order': 100}}, 'scaled': 5.03, 'properties': {'a': {'scaled': 4.02, 'order': 2}, 'b': {'scaled': 4.01, 'order': 1}}, 'order': 3}, 'BasicComponent': {'relationships': {'basicDevice': {'scaled': 4.0, 'order': 100}}, 'scaled': 5.01, 'properties': {'a': {'scaled': 4.01, 'order': 1}, 'b': {'scaled': 4.02, 'order': 2}}, 'order': 1}, 'BasicDevice': {'relationships': {'basicComponents': {'scaled': 7.0, 'order': 100}}, 'scaled': 6.0, 'properties': {'a': {'scaled': 4.01, 'order': 1}, 'c': {'scaled': 4.03, 'order': 3}, 'b': {'scaled': 4.02, 'order': 2}}, 'order': 100}, 'SubComponent': {'relationships': {'basicDevice': {'scaled': 3.02, 'order': 2}, 'auxComponents': {'scaled': 6.01, 'order': 1}}, 'scaled': 5.02, 'properties': {'a': {'scaled': 4.01, 'order': 1}, 'b': {'scaled': 4.02, 'order': 2}}, 'order': 2}}
+
+EXPECTED_FLOAT = {'AuxComponent': {'relationships': {'basicDevice': {'scaled': 3.01, 'order': 1}, 'auxComponents': {'scaled': 6.02, 'order': 2}, 'subComponents': {'scaled': 7.0, 'order': 100}}, 'scaled': 5.03, 'properties': {'a': {'scaled': 4.02, 'order': 2}, 'b': {'scaled': 4.01, 'order': 1}}, 'order': 3}, 'BasicComponent': {'relationships': {'basicDevice': {'scaled': 4.0, 'order': 100}}, 'scaled': 5.01, 'properties': {'a': {'scaled': 4.02, 'order': 2}, 'b': {'scaled': 4.01, 'order': 1}}, 'order': 1}, 'BasicDevice': {'relationships': {'basicComponents': {'scaled': 7.0, 'order': 100}}, 'scaled': 5.04, 'properties': {'a': {'scaled': 4.01, 'order': 1}, 'c': {'scaled': 4.03, 'order': 3}, 'b': {'scaled': 4.02, 'order': 2}}, 'order': 4}, 'SubComponent': {'relationships': {'basicDevice': {'scaled': 3.01, 'order': 1}, 'auxComponents': {'scaled': 6.02, 'order': 2}}, 'scaled': 5.02, 'properties': {'a': {'scaled': 4.02, 'order': 2}, 'b': {'scaled': 4.01, 'order': 1}}, 'order': 2}}
+
+EXPECTED_DEFAULT = {'AuxComponent': {'relationships': {'basicDevice': {'scaled': 3.02, 'order': 2}, 'auxComponents': {'scaled': 6.01, 'order': 1}, 'subComponents': {'scaled': 7.0, 'order': 100}}, 'scaled': 5.04, 'properties': {'a': {'scaled': 4.01, 'order': 1}, 'b': {'scaled': 4.02, 'order': 2}}, 'order': 4}, 'BasicComponent': {'relationships': {'basicDevice': {'scaled': 4.0, 'order': 100}}, 'scaled': 5.02, 'properties': {'a': {'scaled': 4.01, 'order': 1}, 'b': {'scaled': 4.02, 'order': 2}}, 'order': 2}, 'BasicDevice': {'relationships': {'basicComponents': {'scaled': 7.0, 'order': 100}}, 'scaled': 5.01, 'properties': {'a': {'scaled': 4.01, 'order': 1}, 'c': {'scaled': 4.03, 'order': 3}, 'b': {'scaled': 4.02, 'order': 2}}, 'order': 1}, 'SubComponent': {'relationships': {'basicDevice': {'scaled': 3.02, 'order': 2}, 'auxComponents': {'scaled': 6.01, 'order': 1}}, 'scaled': 5.03, 'properties': {'a': {'scaled': 4.01, 'order': 1}, 'b': {'scaled': 4.02, 'order': 2}}, 'order': 3}}
+
+class TestOrderHandlers(BaseTestCase):
+    """
+        Validate handling, normalization, and scaling of order parameter across Specs
+    """
+
+    def test_order_as_default(self):
+        """Test handling of default order assignment"""
+        z = ZPLTestHarness(YAML_DOC)
+        self.assertEquals(EXPECTED_DEFAULT, self.get_order_data(z),
+                          'Order parameter handling (default) failed validation')
+
+    def test_order_as_float(self):
+        """Test handling of legacy float order assignment"""
+        z = ZPLTestHarness(YAML_DOC_FLOAT)
+        self.assertEquals(EXPECTED_FLOAT, self.get_order_data(z),
+                          'Order parameter handling (float) failed validation')
+
+    def test_order_as_integer(self):
+        """test ZPl 2.0 normal order"""
+        z = ZPLTestHarness(YAML_DOC_INT)
+        self.assertEquals(EXPECTED_INT, self.get_order_data(z),
+                          'Order parameter handling (integer) failed validation')
+
+    def get_order_data(self, z):
+        data = {}
+        for spec in z.cfg.classes.values():
+            data[spec.name] = {'properties': {}, 'relationships': {}, 'order': spec.order, 'scaled': spec.scaled_order}
+            for p_spec in spec.properties.values():
+                data[spec.name]['properties'][p_spec.name] = {'order': p_spec.order, 'scaled': p_spec.scaled_order}
+            for r_spec in spec.relationships.values():
+                data[spec.name]['relationships'][r_spec.name] = {'order': r_spec.order, 'scaled': r_spec.scaled_order}
+        return data
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestOrderHandlers))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/docs/yaml-classes-and-relationships.rst
+++ b/docs/yaml-classes-and-relationships.rst
@@ -500,11 +500,32 @@ initial_sort_column
   :Default Value: name
 
 order
-  :Description: Order to display this class among other classes. (0-100)
+  :Description: Order to display this class among other classes. (1-100)
   :Required: No
   :Type: integer
-  :Default Value: 50
+  :Default Value: 100
   
+.. note::
+
+      The *order* parameter takes any integer value between 1 and 100.
+      However, it's behavior depends somewhat depending on whether it applies
+      to a Class, a Property, or a Relationship.  For a relationship, order 
+      behavior can further depend on the type of relationship.
+
+      There is an overall clustering for like items in the GUI component grid, following
+      this order:
+      
+      1. Containing Components
+      2. Properties
+      3. Contained Components
+
+      with container relationships listed before visible properties and finally any
+      containing relationships. 
+      
+      Earlier (pre-2.0) versions of ZenPackLib accepted float arguments for order.  However,
+      ZenPackLib now "normalizes" these values behind the scenes to integers between
+      1 and 100.
+      
 filter_display
   :Description: Will related components be filterable by components of this type?
   :Required: No
@@ -569,7 +590,7 @@ dynamicview_weight
   :Description: Dynamic View weight for objects of this class. Higher numbers are further to the right. Can be overridden by implementing getDynamicViewGroup() method on class.
   :Required: No
   :Type: float or int
-  :Default: 1000 + (order * 100)
+  :Default: 1000 + order * 10
   
 dynamicview_relations
   :Description: Map of Dynamic View relationships for this class and the relationship or method names that when called populate them.
@@ -691,10 +712,10 @@ grid_display
   :Default Value: true
   
 order
-  :Description: Order to display this property among other properties. (0-100)
+  :Description: Order to display this property among other properties. (1-100)
   :Required: No
   :Type: integer
-  :Default Value: 45
+  :Default Value: 100
   
 editable
   :Description: Should this property be editable in details?
@@ -816,10 +837,10 @@ grid_display
   :Default Value: true
   
 order
-  :Description: Order to display this relationship among other relationships and properties. (0-10)
+  :Description: Order to display this relationship among other relationships and properties. (1-100)
   :Required: No
-  :Type: float
-  :Default Value: 3.0 for To-One, 6.0 for To-Many.
+  :Type: integer
+  :Default Value: 100
   
 renderer
   :Description: JavaScript renderer for relationship value.


### PR DESCRIPTION
The "order" parameter is now expected to be an integer between 1 and 100
for classes, properties, and relationships with a default of 50.  This
was the documented behavior but the implementation was less consistent.
 
Float arguments are still accepted, but normalized to integer between
1-100.

- Added methods to spec to deal with setting, normalizing, and scaling
the order parameter where appropriate.
- Implemented float detection to determine if order parameter on
properties, relationships, or classes needs to be renormalized.
- Added a note explaining order parameter behavior to documentation.