### PR TITLE
Fix installation bug

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -301,7 +301,7 @@ class ZenPack(ZenPackBase):
         for zprop, value in dcspec.zProperties.iteritems():
             # Avoid setting zProperties on an existing device class
             if exists:
-                if value != getattr(dcObject, zprop):
+                if value != getattr(dcObject, zprop, None):
                     self.LOG.debug('Not setting "{}" to "{}" on existing device class ({})'.format(zprop, value, dcspec.path))
                 continue
             if dcObject.getPropertyType(zprop) is None:


### PR DESCRIPTION
- Found issue where nonexistent zProperty (like zCredentialsZProperties
in 4.2.5) causes installation to fail.