### PR TITLE
Updates for event class spec in zpl

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
@@ -478,18 +478,18 @@ class ZPLCommand(ZenScriptBase):
         eventclasses = collections.defaultdict(dict)
         for eventclass in [x for x in zenpack.packables() if x.meta_type == 'EventClass']:
             ec_name = "/" + "/".join(eventclass.getPrimaryUrlPath().split('/')[4:])
-            eventclasses[ec_name] = EventClassSpecParams.fromObject(eventclass, create=True, remove=True)
+            eventclasses[ec_name] = EventClassSpecParams.fromObject(eventclass, remove=True)
             for subclass in eventclass.getSubEventClasses():
                 ec_name = "/" + "/".join(subclass.getPrimaryUrlPath().split('/')[4:])
                 # Remove = false because the removing the parent will remove the child # This is a performance optimization
-                eventclasses[ec_name] = EventClassSpecParams.fromObject(subclass, create=True, remove=False)
+                eventclasses[ec_name] = EventClassSpecParams.fromObject(subclass, remove=False)
 
         for eventclassinst in [x for x in zenpack.packables() if x.meta_type == 'EventClassInst']:
             eventclass = eventclassinst.eventClass()
             ec_name = "/" + "/".join(eventclass.getPrimaryUrlPath().split('/')[4:])
 
             # Do not create/remove the eventclasses as we do not own them
-            eventclassspec = eventclasses.get(ec_name, EventClassSpecParams.new(ec_name, remove=False, create=False))
+            eventclassspec = eventclasses.get(ec_name, EventClassSpecParams.new(ec_name, remove=False))
             if eventclassinst.id in eventclassspec.mappings:
                 # we have already gotten this instance and we don't need a duplicate
                 continue

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassSpecParams.py
@@ -22,24 +22,22 @@ class EventClassSpecParams(SpecParams, EventClassSpec):
             EventClassMappingSpecParams, 'mappings', mappings)
 
     @classmethod
-    def new(cls, eventclass, description='', transform='', create=False, remove=False):
+    def new(cls, eventclass, description='', transform='', remove=False):
         self = object.__new__(cls)
         SpecParams.__init__(self)
         self.path = eventclass
         self.description = description
         self.transform = transform
-        self.create = create
         self.remove = remove
         return self
 
     @classmethod
-    def fromObject(cls, eventclass, create=False, remove=False):
+    def fromObject(cls, eventclass, remove=False):
         self = object.__new__(cls)
         SpecParams.__init__(self)
 
         self.description = eventclass.description
         self.transform = eventclass.transform
-        self.create = create
         self.remove = remove
         self.mappings = {x.id: EventClassMappingSpecParams.fromObject(x) for x in eventclass.instances()}
         return self

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_event_class.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_event_class.py
@@ -26,7 +26,6 @@ EVENT_CLASS_YAML = """
 name: ZenPacks.zenoss.ZenPackLib
 event_classes:
   /Status/Test:
-    create: true
     remove: false
     description: Test event class
     transform: "from ZenPacks.zenoss.CiscoMonitor import transforms\\ntransforms.status_handler(device, component, evt)"
@@ -55,8 +54,6 @@ class TestEventClass(BaseTestCase):
         self.assertEquals(len(event_class_zp.yaml['event_classes']), len(event_class_zp.cfg.event_classes))
         self.assertEquals(event_class_zp.yaml['event_classes'].keys()[0], event_class_zp.cfg.event_classes.keys()[0])
         self.assertTrue('/Status/Test' in event_class_zp.cfg.event_classes.keys())
-        self.assertTrue(event_class_zp.yaml['event_classes']['/Status/Test']['create'])
-        self.assertTrue(event_class_zp.cfg.event_classes['/Status/Test'].create)
         self.assertFalse(event_class_zp.yaml['event_classes']['/Status/Test']['remove'])
         self.assertFalse(event_class_zp.cfg.event_classes['/Status/Test'].remove)
         self.assertEquals(len(event_class_zp.yaml['event_classes']['/Status/Test']['mappings']),

--- a/docs/yaml-event-classes.rst
+++ b/docs/yaml-event-classes.rst
@@ -4,18 +4,11 @@
 Event Classes
 #############
 
-Event Classes are used to group together specific types of events.  This can be useful
-for situations where an event should be dropped or text should be altered to be more
-human readable.  This is typically done through a python transform.
+Event Classes are used to group together specific types of events.  This can be useful for situations where an event should be dropped or text should be altered to be more human readable.  This is typically done through a python transform.
 
-To define a class, supply the path to the class or classes.  Then, for each event class,
-supply the appropriate properties for the class.  These include the option to create
-and/or remove the event class during ZenPack installation/uninstallation, description,
-and a transform.  You can also define mappings to apply to events based on a key and
-supply an explanation and/or resolution to an issue.
+To define a class, supply the path to the class or classes.  Then, for each event class, supply the appropriate properties for the class.  These include the option to remove the event class during ZenPack installation/uninstallation, description, and a transform.  You can also define mappings to apply to events based on a key and supply an explanation and/or resolution to an issue.
 
-The following example shows an example of a `zenpack.yaml` file with an example
-of a definition of an event class.
+The following example shows an example of a `zenpack.yaml` file with an example of a definition of an event class.
 
 .. code-block:: yaml
 
@@ -23,7 +16,6 @@ of a definition of an event class.
 
     event_classes:
       /Status/Acme:
-        create: true
         remove: false
         description: Acme event class
         mappings:
@@ -40,7 +32,7 @@ of a definition of an event class.
 Event Class Fields
 ******************
 
-The following fields are valid for a process class organizer entry.
+The following fields are valid for an event class entry.
 
 path
   :Description: Path to the Event Class (e.g. /Status/Acme).  Must begin with "/".
@@ -54,14 +46,8 @@ description
   :Type: string
   :Default Value: None
 
-create
-  :Description: Create the event class during installation?
-  :Required: No
-  :Type: boolean
-  :Default Value: True
-
 remove
-  :Description: Remove the event class during uninstallation?
+  :Description: Remove the event class during ZenPack removal?  This will only apply to a ZenPack that has created the event class.  Any existing event classes not created by the ZenPack will not be removed.  Any event classes created by the platform will also never be removed.
   :Required: No
   :Type: boolean
   :Default Value: False


### PR DESCRIPTION
The 'create' flag is essentially redundant.  if a user is
specifying an event class then they obviously want it to be created.
For the removal we just need to know if it was created by the zpl.
Also we are making sure not to remove platform event classes.

Fixes ZPS-433