### PR TITLE
Simpler fix to ensure correct device status icon for up/down

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/DeviceBase.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/DeviceBase.py
@@ -23,7 +23,7 @@ class DeviceBase(ModelBase):
 
     """
 
-    def getStatus(self, statusclass="/Status", **kwargs):
+    def getStatus(self, statusclass="/Status/*", **kwargs):
         """Return status number for this device.
 
         The status number is the number of critical events associated
@@ -48,15 +48,6 @@ class DeviceBase(ModelBase):
         events are not considered as affecting the device's status.
 
         """
-
-        def get_sub_classes(name):
-            for ev in self.dmd.Events.getSubEventClasses():
-                evkey = ev.getDmdKey()
-                if name in evkey:
-                    yield evkey
-
-        ev_classes = filter(None, list(get_sub_classes(statusclass)))
-
         if not self.monitorDevice():
             return None
 
@@ -67,7 +58,7 @@ class DeviceBase(ModelBase):
                 element_sub_identifier=[""],
                 severity=[SEVERITY_CRITICAL],
                 status=[STATUS_NEW, STATUS_ACKNOWLEDGED],
-                event_class=ev_classes)
+                event_class=filter(None, [statusclass]))
 
             result = zep.getEventSummaries(0, filter=event_filter, limit=0)
         except Exception:


### PR DESCRIPTION
- changed default statusclass paramter to wildcard "/Status/*"
- reverted earlier changes