### PR TITLE
Fix ZenPack install template change detection inadequacies

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -113,16 +113,19 @@ class RRDTemplateSpec(Spec):
                                                             spec_name,
                                                             ', '.join(list(invalid_names))))
 
-    def create(self, dmd, addToZenPack=True):
+    def create(self, dmd, addToZenPack=True, id=None):
         device_class = dmd.Devices.createOrganizer(self.deviceclass_spec.path)
 
-        existing_template = device_class.rrdTemplates._getOb(self.name, None)
+        # override object id if provided
+        t_id = id or self.name
+
+        existing_template = device_class.rrdTemplates._getOb(t_id, None)
         if existing_template:
             self.speclog.info("replacing template")
-            device_class.rrdTemplates._delObject(self.name)
+            device_class.rrdTemplates._delObject(t_id)
 
-        device_class.manage_addRRDTemplate(self.name)
-        template = device_class.rrdTemplates._getOb(self.name)
+        device_class.manage_addRRDTemplate(t_id)
+        template = device_class.rrdTemplates._getOb(t_id)
 
         # Flag this as a ZPL managed object, that is, one that should not be
         # exported to objects.xml  (contained objects will also be excluded)
@@ -156,3 +159,14 @@ class RRDTemplateSpec(Spec):
 
         if not addToZenPack:
             return template
+
+    def remove(self, dmd, id=None):
+        try:
+            device_class = dmd.Devices.getOrganizer(self.deviceclass_spec.path)
+        except KeyError:
+            return
+        # override object id if provided
+        t_id = id or self.name
+        existing_template = device_class.rrdTemplates._getOb(t_id, None)
+        if existing_template:
+            device_class.rrdTemplates._delObject(t_id)

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
@@ -23,7 +23,6 @@ from Products.ZenTestCase.BaseTestCase import BaseTestCase
 
 # zenpacklib Imports
 from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
-from ZenPacks.zenoss.ZenPackLib.lib.base.ZenPack import ZenPack
 
 
 YAML_DOC = """name: ZenPacks.zenoss.ZenPackLib
@@ -303,14 +302,19 @@ class TestTemplateModified(BaseTestCase):
         z_new = ZPLTestHarness(new_doc)
         z_orig.connect()
         z_new.connect()
-        zenpack = ZenPack(z_new.dmd)
+
         # original template spec
         orig_tspec = z_orig.cfg.device_classes.get('/Server').templates.get('Device')
         # template based on original spec
         orig_template = orig_tspec.create(z_orig.dmd, False)
+
+        zenpack = z_new.schema.ZenPack(z_new.dmd)
         # new temlate spec
         new_tspec = z_new.cfg.device_classes.get('/Server').templates.get('Device')
-        diff = zenpack.template_changed(z_new, orig_template, new_tspec)
+        new_tspec_param = zenpack._v_specparams.device_classes.get('/Server').templates.get('Device')
+
+        diff = zenpack.object_changed(z_new.dmd, orig_template, new_tspec, new_tspec_param)
+
         self.assertEquals(diff, expected, 'Expected:\n{}\ngot:\n{}'.format(expected, diff))
 
 


### PR DESCRIPTION
- Found while reviewing ZPS-102
- Template upgrade changes not being detected when upgrading between
.egg files
- Moved template detection to "install" method from "remove" method
since the "remove" method uses the old (existing) specs for comparison
(thus finding no difference).
- replaced the "template_changed" method with more general
"object_changed" method that can handle other types of objects
- added "object_changed_safe" method which, although less accurate,
removes the intermediate dummy object creation/removal (so it may be
better suited for device classes and other organizer specs).
- modifed RRDTemplateSpec "create" method to accept optional object id
parameter
- added RRDTemplateSpec "remove" method to faciliate object removal