### PR TITLE
Update to class override logging and documentation (ZPS-112)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -762,6 +762,7 @@ class ClassSpec(Spec):
         if self.path_pattern_streams:
             attributes['_v_path_pattern_streams'] = self.path_pattern_streams
 
+        attributes['LOG'] = self.LOG
         return self.create_schema_class(
             get_symbol_name(self.zenpack.name, 'schema'),
             self.name,

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -119,8 +119,18 @@ would be accessed as follows:
               self.LOG.info("You called hello_world")
               return 'Hello World!'
 
-Logging used within class extension files will follow the verbosity and level parameters provided to the
-"load_yaml" method.
+
+
+.. note::
+
+   Log messages generated within the new logging framework are written to the Zope logger (event.log) 
+   and can be viewed there.  Logging used within class extension files will follow the verbosity 
+   and level parameters provided to the "load_yaml" method.
+   
+   Please note that additional Zope configuration may be required to see log messages, since Zope 
+   configuration determines what is accepted for writing to its event log.  For example, if Zope logging
+   is set to "warn", then any "info" or "debug" messages will not be logged regardless of the load_yaml parameters
+   used.  Zope logging in this case must be set to "info" for ZPL "info", "warning", and "critical" logging.
 
 .. _older-versions:
 


### PR DESCRIPTION
- Fixes ZPS-112
- ClassSpec updated to ensure that per-ZP logging extends to created
classes (and used by class overrides).
- Documentation updated with a note about logging verbosity.