### PR TITLE
Update example __init__ used in zenpacklib --create

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,12 +7,13 @@ maintain their own zenpacklib.py versions.
 Centralized Usage
 ************************
 
-To use this version of zenpacklib, change your ZenPack  __init__.py statement to:
+To use this version of zenpacklib, your ZenPack's  __init__.py must include:
 
-import os
 from ZenPacks.zenoss.ZenPackLib import zenpacklib
-YAML = os.path.join(os.path.dirname(__file__), 'zenpack.yaml')
-CFG = zenpacklib.load_yaml(YAML)
+
+# verbose and level are optional
+CFG = zenpacklib.load_yaml(verbose=False, level=30)
+schema = CFG.zenpack_module.schema
 
 ************************
 Distributed Usage

--- a/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
@@ -289,10 +289,9 @@ class ZPLCommand(ZenScriptBase):
         print "  - creating file: {}".format(init_fname)
         with open(init_fname, 'w') as init_f:
             init_f.write(
-                "import os\n"
                 "from ZenPacks.zenoss.ZenPackLib import zenpacklib\n\n"
-                "FILE=os.path.join(os.path.dirname(__file__), 'zenpack.yaml')\n"
-                "CFG = zenpacklib.load_yaml(FILE)\n")
+                "CFG = zenpacklib.load_yaml(verbose=False, level=30)\n"
+                "schema = CFG.zenpack_module.schema\n")
 
         # Create zenpack.yaml in ZenPack module directory.
         yaml_fname = os.path.join(module_directory, 'zenpack.yaml')


### PR DESCRIPTION
- removed os import and filename/path specification (no longer needed)
- added optional "verbose" and "level" parameters for demonstration 
- added "schema" line to facilitate class overrides.
- Updated README.txt to reflect latest usage