### PR TITLE
Document what happens when event/process class exists

### DIFF
--- a/docs/yaml-event-classes.rst
+++ b/docs/yaml-event-classes.rst
@@ -26,6 +26,10 @@ The following example shows an example of a `zenpack.yaml` file with an example 
             transform: "if evt.message.find('Error reading value for') >= 0:\n\
               \   evt._action = 'drop'"
 
+.. note::
+
+  When you define an event class and/or mapping which already exists, any settings defined in your ZenPack will overwrite existing settings.
+
 .. _event-class-fields:
 
 ******************

--- a/docs/yaml-process-classes.rst
+++ b/docs/yaml-process-classes.rst
@@ -32,6 +32,10 @@ of a definition of a process class.
             replaceRegex: .*
             replacement: Widget
 
+.. _note::
+
+  When you define a process class organizer and/or class which already exists, any settings defined in your ZenPack will overwrite existing settings.
+
 .. _process-class-organizer-fields:
 
 ******************************


### PR DESCRIPTION
Fixes ZPS-432

If an event or process class is previously defined, then we
update the properties if they are different.