### PR TITLE
Fix Unit test Failure (ZPS-462)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
@@ -311,7 +311,7 @@ class TestTemplateModified(BaseTestCase):
         zenpack = z_new.schema.ZenPack(z_new.dmd)
         # new temlate spec
         new_tspec = z_new.cfg.device_classes.get('/Server').templates.get('Device')
-        new_tspec_param = zenpack._v_specparams.device_classes.get('/Server').templates.get('Device')
+        new_tspec_param = z_new.cfg.specparams.device_classes.get('/Server').templates.get('Device')
 
         diff = zenpack.object_changed(z_new.dmd, orig_template, new_tspec, new_tspec_param)
 


### PR DESCRIPTION
- Fixes ZPS-462
- Updated test_template_modify.py to work when used with runtests