### PR TITLE
Fix inherited property sort order

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
@@ -271,7 +271,7 @@ class ClassPropertySpec(Spec):
 
         return [
             OrderAndValue(
-                order=self.order,
+                order=self.scaled_order,
                 value='{{{}}}'.format(',\n                       '.join(column_fields))),
             ]
 


### PR DESCRIPTION
- Update js_columns method in ClassPropertySpec to use "scaled_order"
instead of "order"