### PR TITLE
ZenPack installation fails for some Event and Process classes (ZEN-26543)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
@@ -35,7 +35,7 @@ class EventClassSpec(Spec):
         """
         super(EventClassSpec, self).__init__(_source_location=_source_location)
         self.zenpack_spec = zenpack_spec
-        self.path = path
+        self.path = path.lstrip('/')
         self.description = description
         self.transform = transform
         self.remove = bool(remove)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
@@ -31,7 +31,8 @@ class ProcessClassOrganizerSpec(Spec):
           :param remove: Remove Organizer on ZenPack removal
           :type remove: boolean
         """
-        self.path = path
+        self.zenpack_spec = zenpack_spec
+        self.path = path.lstrip('/')
         self.description = description
         self.remove = remove
         self.process_classes = self.specs_from_param(
@@ -44,7 +45,7 @@ class ProcessClassOrganizerSpec(Spec):
             porg = dmd.Processes.getOrganizer(self.path)
             bCreated = getattr(porg, 'zpl_managed', False)
         except KeyError:
-            manage_addOSProcessOrganizer(dmd.Processes, self.path)
+            dmd.Processes.createOrganizer(self.path)
             porg = dmd.Processes.getOrganizer(self.path)
             bCreated = True
 


### PR DESCRIPTION

- Fixes ZEN-26543
- Ensure that leading '/' character removed from 'path' attribute (as is
done in DeviceClassSpec
- Set 'zenpack_spec' attribute in ProcessClassOrganizerSpec
- ProcessClassOrganizerSpec now uses "createOrganizer" to handle nested
organizers