### PR TITLE
Replace "zenpacklib" with "ZenPack SDK"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
-######################
-Welcome to zenpacklib!
-######################
+###########################
+Welcome to the ZenPack SDK!
+###########################
 
-zenpacklib is a Python library that makes building common types of ZenPacks
-simpler, faster, more consistent and more accurate.
+The ZenPack SDK includes zenpacklib: a library that makes building common types
+of ZenPacks simpler, faster, more consistent and more accurate.
 
 ZenPacks are a plugin mechanism for Zenoss. Most commonly they're used to
 extend Zenoss to monitor new types of targets. It is specifically this common

--- a/README.txt
+++ b/README.txt
@@ -58,12 +58,12 @@ YAML = os.path.join(os.path.dirname(__file__), 'zenpack.yaml')
 CFG = zenpacklib.load_yaml(YAML)
 
 
-######################
-Welcome to zenpacklib!
-######################
+###########################
+Welcome to the ZenPack SDK!
+###########################
 
-zenpacklib is a Python library that makes building common types of ZenPacks
-simpler, faster, more consistent and more accurate.
+The ZenPack SDK includes zenpacklib: a library that makes building common types
+of ZenPacks simpler, faster, more consistent and more accurate.
 
 ZenPacks are a plugin mechanism for Zenoss. Most commonly they're used to
 extend Zenoss to monitor new types of targets. It is specifically this common

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'zenpacklib'
+project = u'ZenPack SDK'
 copyright = u'2015, Zenoss, Inc.'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -192,7 +192,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'zenpacklib.tex', u'zenpacklib Documentation',
+  ('index', 'zenpacklib.tex', u'ZenPack SDK Documentation',
    u'Zenoss, Inc.', 'manual'),
 ]
 
@@ -222,7 +222,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'zenpacklib', u'zenpacklib Documentation',
+    ('index', 'zenpacklib', u'ZenPack SDK Documentation',
      [u'Zenoss, Inc.'], 1)
 ]
 
@@ -236,7 +236,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'zenpacklib', u'zenpacklib Documentation',
+  ('index', 'zenpacklib', u'ZenPack SDK Documentation',
    u'Zenoss, Inc.', 'zenpacklib', 'One line description of project.',
    'Miscellaneous'),
 ]
@@ -257,7 +257,7 @@ texinfo_documents = [
 # -- Options for Epub output ----------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u'zenpacklib'
+epub_title = u'ZenPack SDK'
 epub_author = u'Zenoss, Inc.'
 epub_publisher = u'Zenoss, Inc.'
 epub_copyright = u'2015, Zenoss, Inc.'


### PR DESCRIPTION
Replacing in as few places as possible since the "ZenPack SDK" currently
only consists of zenpacklib.